### PR TITLE
Version 3.2.2

### DIFF
--- a/.mocharc.cjs
+++ b/.mocharc.cjs
@@ -14,4 +14,5 @@ module.exports = {
 	exclude: [
 		"**/*.d.mts"
 	]
+	// slow: 0
 };

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 [![npm version](https://badge.fury.io/js/%40cowwoc%2Frequirements.svg)](https://badge.fury.io/js/%40cowwoc%2Frequirements)
 [![build-status](https://github.com/cowwoc/requirements.js/workflows/Build/badge.svg)](https://github.com/cowwoc/requirements.js/actions?query=workflow%3ABuild)
 
-# <img src="https://raw.githubusercontent.com/cowwoc/requirements.js/release-3.2.1/wiki/checklist.svg?sanitize=true" width=64 height=64 alt="checklist"> Fluent API for Design Contracts
+# <img src="https://raw.githubusercontent.com/cowwoc/requirements.js/release-3.2.2/wiki/checklist.svg?sanitize=true" width=64 height=64 alt="checklist"> Fluent API for Design Contracts
 
-[![API](https://img.shields.io/badge/api_docs-5B45D5.svg)](https://cowwoc.github.io/requirements.js/3.2.1/docs/api/)
+[![API](https://img.shields.io/badge/api_docs-5B45D5.svg)](https://cowwoc.github.io/requirements.js/3.2.2/docs/api/)
 [![Changelog](https://img.shields.io/badge/changelog-A345D5.svg)](wiki/Changelog.md)
 [![java](https://img.shields.io/badge/other%20languages-java-457FD5.svg)](../../../requirements.java)
 
@@ -17,13 +17,13 @@ A [fluent API](https://en.wikipedia.org/wiki/Fluent_interface) for enforcing
 To get started, add this dependency:
 
 ```shell
-npm install --save @cowwoc/requirements@3.2.1
+npm install --save @cowwoc/requirements@3.2.2
 ```
 
 or [pnpm](https://pnpm.io/):
 
 ```shell
-pnpm add @cowwoc/requirements@3.2.1
+pnpm add @cowwoc/requirements@3.2.2
 ```
 
 The contents of the API classes depend on which [modules](wiki/Supported_Libraries.md) are enabled.
@@ -67,13 +67,13 @@ Actual: 15
 The best way to learn about the API is using your IDE's auto-complete engine.
 There are six entry points you can navigate from:
 
-* [requireThat(value, name)](https://cowwoc.github.io/requirements.js/3.2.1/docs/api/module-DefaultRequirements.html#~requireThat)
-* [validateThat(value, name)](https://cowwoc.github.io/requirements.js/3.2.1/docs/api/module-DefaultRequirements.html#~validateThat)
-* [assertThat(Function)](https://cowwoc.github.io/requirements.js/3.2.1/docs/api/module-DefaultRequirements.html#~assertThat)
-* [assertThatAndReturn(Function)](https://cowwoc.github.io/requirements.js/3.2.1/docs/api/module-DefaultRequirements.html#~assertThatAndReturn)
+* [requireThat(value, name)](https://cowwoc.github.io/requirements.js/3.2.2/docs/api/module-DefaultRequirements.html#~requireThat)
+* [validateThat(value, name)](https://cowwoc.github.io/requirements.js/3.2.2/docs/api/module-DefaultRequirements.html#~validateThat)
+* [assertThat(Function)](https://cowwoc.github.io/requirements.js/3.2.2/docs/api/module-DefaultRequirements.html#~assertThat)
+* [assertThatAndReturn(Function)](https://cowwoc.github.io/requirements.js/3.2.2/docs/api/module-DefaultRequirements.html#~assertThatAndReturn)
 
-* [Requirements](https://cowwoc.github.io/requirements.js/3.2.1/docs/api/module-Requirements-Requirements.html)
-* [GlobalRequirements](https://cowwoc.github.io/requirements.js/3.2.1/docs/api/module-GlobalRequirements-GlobalRequirements.html)
+* [Requirements](https://cowwoc.github.io/requirements.js/3.2.2/docs/api/module-Requirements-Requirements.html)
+* [GlobalRequirements](https://cowwoc.github.io/requirements.js/3.2.2/docs/api/module-GlobalRequirements-GlobalRequirements.html)
 
 ## Best practices
 

--- a/build.mts
+++ b/build.mts
@@ -84,8 +84,10 @@ class Build
 
 		// tsconfig.json references the tests to suppress an ESLint warning, but we don't actually want to publish
 		// them.
-		const index = config.include.indexOf("test/**/*.mts", 0);
-		config.include.splice(index, 1);
+		config.include = config.include.filter((element: string) =>
+		{
+			return element !== "build.mts" && !element.startsWith("test/");
+		});
 		config.compilerOptions.outDir = "target/publish/node/";
 		config.compilerOptions.declaration = true;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@cowwoc/requirements",
-	"version": "3.2.1",
+	"version": "3.2.2",
 	"keywords": [
 		"preconditions",
 		"postconditions",

--- a/src/ArrayValidator.mts
+++ b/src/ArrayValidator.mts
@@ -13,22 +13,24 @@ import type {
  * exceptions.
  *
  * All methods (except those found in {@link ObjectValidator}) imply {@link isNotNull}.
+ *
+ * @typeParam E - the type the array elements
  */
-interface ArrayValidator extends ExtensibleObjectValidator<ArrayValidator>
+interface ArrayValidator<E> extends ExtensibleObjectValidator<ArrayValidator<E>, E[]>
 {
 	/**
 	 * Ensures that the actual value is empty.
 	 *
 	 * @returns the updated validator
 	 */
-	isEmpty(): ArrayValidator;
+	isEmpty(): ArrayValidator<E>;
 
 	/**
 	 * Ensures that the actual value is not empty.
 	 *
 	 * @returns the updated validator
 	 */
-	isNotEmpty(): ArrayValidator;
+	isNotEmpty(): ArrayValidator<E>;
 
 	/**
 	 * Ensures that the array contains an element.
@@ -39,7 +41,7 @@ interface ArrayValidator extends ExtensibleObjectValidator<ArrayValidator>
 	 * @throws TypeError if <code>name</code> is null
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	contains(element: unknown, name?: string): ArrayValidator;
+	contains(element: E, name?: string): ArrayValidator<E>;
 
 	/**
 	 * Ensures that the array contains exactly the specified elements; nothing less, nothing more.
@@ -50,7 +52,7 @@ interface ArrayValidator extends ExtensibleObjectValidator<ArrayValidator>
 	 * @throws TypeError if <code>name</code> is null
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	containsExactly(expected: unknown[], name?: string): ArrayValidator;
+	containsExactly(expected: E[], name?: string): ArrayValidator<E>;
 
 	/**
 	 * Ensures that the array contains any of the specified elements.
@@ -61,7 +63,7 @@ interface ArrayValidator extends ExtensibleObjectValidator<ArrayValidator>
 	 * @throws TypeError if <code>name</code> is null
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	containsAny(expected: unknown[], name?: string): ArrayValidator;
+	containsAny(expected: E[], name?: string): ArrayValidator<E>;
 
 	/**
 	 * Ensures that the array contains all the specified elements.
@@ -72,7 +74,7 @@ interface ArrayValidator extends ExtensibleObjectValidator<ArrayValidator>
 	 * @throws TypeError if <code>name</code> is null
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	containsAll(expected: unknown[], name?: string): ArrayValidator;
+	containsAll(expected: E[], name?: string): ArrayValidator<E>;
 
 	/**
 	 * Ensures that the array does not contain an element.
@@ -83,7 +85,7 @@ interface ArrayValidator extends ExtensibleObjectValidator<ArrayValidator>
 	 * @throws TypeError if <code>name</code> is null
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	doesNotContain(element: unknown, name?: string): ArrayValidator;
+	doesNotContain(element: E, name?: string): ArrayValidator<E>;
 
 	/**
 	 * Ensures that the array does not contain any of the specified elements.
@@ -94,7 +96,7 @@ interface ArrayValidator extends ExtensibleObjectValidator<ArrayValidator>
 	 * @throws TypeError if <code>name</code> is null
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	doesNotContainAny(elements: unknown[], name?: string): ArrayValidator;
+	doesNotContainAny(elements: E[], name?: string): ArrayValidator<E>;
 
 	/**
 	 * Ensures that the array does not contain all the specified elements.
@@ -105,14 +107,14 @@ interface ArrayValidator extends ExtensibleObjectValidator<ArrayValidator>
 	 * @throws TypeError if <code>name</code> is null
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	doesNotContainAll(elements: unknown[], name?: string): ArrayValidator;
+	doesNotContainAll(elements: E[], name?: string): ArrayValidator<E>;
 
 	/**
 	 * Ensures that the array does not contain any duplicate elements.
 	 *
 	 * @returns the updated validator
 	 */
-	doesNotContainDuplicates(): ArrayValidator;
+	doesNotContainDuplicates(): ArrayValidator<E>;
 
 	/**
 	 * @returns a validator for the length of the array
@@ -124,23 +126,44 @@ interface ArrayValidator extends ExtensibleObjectValidator<ArrayValidator>
 	 * @returns the updated validator
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	lengthConsumer(consumer: (length: NumberValidator) => void): ArrayValidator;
+	lengthConsumer(consumer: (length: NumberValidator) => void): ArrayValidator<E>;
+
+	/**
+	 * @returns a validator for the <code>Array</code>
+	 * @deprecated returns this
+	 */
+	asArray(): ArrayValidator<E>;
+
+	asArray<E>(): ArrayValidator<E>;
+
+	/**
+	 * @param consumer - a function that accepts a {@link ArrayValidator} for the actual value
+	 * @returns the updated validator
+	 * @throws TypeError if <code>consumer</code> is not set
+	 */
+	asArrayConsumer(consumer: (input: ArrayValidator<E>) => void): ArrayValidator<E>;
+
+	asArrayConsumer<E>(consumer: (input: ArrayValidator<E>) => void): ArrayValidator<E>;
 
 	/**
 	 * Verifies the Set representation of the array.
 	 *
 	 * @returns a <code>Set</code> validator
 	 */
-	asSet(): SetValidator;
+	asSet(): SetValidator<E>;
+
+	asSet<E>(): SetValidator<E>;
 
 	/**
 	 * @param consumer - a function that accepts a {@link SetValidator} for the Set representation of the array
 	 * @returns the updated validator
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	asSetConsumer(consumer: (actual: SetValidator) => void): ArrayValidator;
+	asSetConsumer(consumer: (actual: SetValidator<E>) => void): ArrayValidator<E>;
 
-	getActual(): unknown[] | void;
+	asSetConsumer<E>(consumer: (actual: SetValidator<E>) => void): ArrayValidator<E>;
+
+	getActual(): E[] | undefined;
 }
 
 export {type ArrayValidator};

--- a/src/ArrayVerifier.mts
+++ b/src/ArrayVerifier.mts
@@ -8,8 +8,10 @@ import type {
  * Verifies the requirements of an array.
  *
  * All methods (except those found in {@link ObjectVerifier}) imply {@link isNotNull}.
+ *
+ * @typeParam E - the type the array elements
  */
-interface ArrayVerifier extends ExtensibleObjectVerifier<ArrayVerifier>
+interface ArrayVerifier<E> extends ExtensibleObjectVerifier<ArrayVerifier<E>, E[]>
 {
 	/**
 	 * Ensures that the actual value is empty.
@@ -17,7 +19,7 @@ interface ArrayVerifier extends ExtensibleObjectVerifier<ArrayVerifier>
 	 * @returns the updated verifier
 	 * @throws RangeError if the actual value is not empty
 	 */
-	isEmpty(): ArrayVerifier;
+	isEmpty(): ArrayVerifier<E>;
 
 	/**
 	 * Ensures that the actual value is not empty.
@@ -25,7 +27,7 @@ interface ArrayVerifier extends ExtensibleObjectVerifier<ArrayVerifier>
 	 * @returns the updated verifier
 	 * @throws RangeError if the actual value is empty
 	 */
-	isNotEmpty(): ArrayVerifier;
+	isNotEmpty(): ArrayVerifier<E>;
 
 	/**
 	 * Ensures that the array contains an element.
@@ -37,7 +39,7 @@ interface ArrayVerifier extends ExtensibleObjectVerifier<ArrayVerifier>
 	 * @throws RangeError if <code>name</code> is empty.
 	 * If the array does not contain <code>element</code>.
 	 */
-	contains(element: unknown, name?: string): ArrayVerifier;
+	contains(element: E, name?: string): ArrayVerifier<E>;
 
 	/**
 	 * Ensures that the array contains exactly the specified elements; nothing less, nothing more.
@@ -51,7 +53,7 @@ interface ArrayVerifier extends ExtensibleObjectVerifier<ArrayVerifier>
 	 * If the array is missing any elements in <code>expected</code>.
 	 * If the array contains elements not found in <code>expected</code>.
 	 */
-	containsExactly(expected: unknown[], name?: string): ArrayVerifier;
+	containsExactly(expected: E[], name?: string): ArrayVerifier<E>;
 
 	/**
 	 * Ensures that the array contains any of the specified elements.
@@ -65,7 +67,7 @@ interface ArrayVerifier extends ExtensibleObjectVerifier<ArrayVerifier>
 	 * If the array is missing any elements in <code>expected</code>.
 	 * If the array contains elements not found in <code>expected</code>.
 	 */
-	containsAny(expected: unknown[], name?: string): ArrayVerifier;
+	containsAny(expected: E[], name?: string): ArrayVerifier<E>;
 
 	/**
 	 * Ensures that the array contains all the specified elements.
@@ -78,7 +80,7 @@ interface ArrayVerifier extends ExtensibleObjectVerifier<ArrayVerifier>
 	 * @throws RangeError if <code>name</code> is empty.
 	 * If the array does not contain all of <code>expected</code>.
 	 */
-	containsAll(expected: unknown[], name?: string): ArrayVerifier;
+	containsAll(expected: E[], name?: string): ArrayVerifier<E>;
 
 	/**
 	 * Ensures that the array does not contain an element.
@@ -90,7 +92,7 @@ interface ArrayVerifier extends ExtensibleObjectVerifier<ArrayVerifier>
 	 * @throws RangeError if <code>name</code> is empty.
 	 * If the array contains <code>element</code>.
 	 */
-	doesNotContain(element: unknown, name?: string): ArrayVerifier;
+	doesNotContain(element: E, name?: string): ArrayVerifier<E>;
 
 	/**
 	 * Ensures that the array does not contain any of the specified elements.
@@ -103,7 +105,7 @@ interface ArrayVerifier extends ExtensibleObjectVerifier<ArrayVerifier>
 	 * @throws RangeError if <code>name</code> is empty.
 	 * If the array contains any of <code>elements</code>.
 	 */
-	doesNotContainAny(elements: unknown[], name?: string): ArrayVerifier;
+	doesNotContainAny(elements: E[], name?: string): ArrayVerifier<E>;
 
 	/**
 	 * Ensures that the array does not contain all the specified elements.
@@ -116,7 +118,7 @@ interface ArrayVerifier extends ExtensibleObjectVerifier<ArrayVerifier>
 	 * @throws RangeError if <code>name</code> is empty.
 	 * If the array contains all of <code>elements</code>.
 	 */
-	doesNotContainAll(elements: unknown[], name?: string): ArrayVerifier;
+	doesNotContainAll(elements: E[], name?: string): ArrayVerifier<E>;
 
 	/**
 	 * Ensures that the array does not contain any duplicate elements.
@@ -124,7 +126,7 @@ interface ArrayVerifier extends ExtensibleObjectVerifier<ArrayVerifier>
 	 * @returns the updated verifier
 	 * @throws RangeError if the array contains any duplicate elements
 	 */
-	doesNotContainDuplicates(): ArrayVerifier;
+	doesNotContainDuplicates(): ArrayVerifier<E>;
 
 	/**
 	 * @returns a verifier for the length of the array
@@ -136,23 +138,46 @@ interface ArrayVerifier extends ExtensibleObjectVerifier<ArrayVerifier>
 	 * @returns the updated verifier
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	lengthConsumer(consumer: (actual: NumberVerifier) => void): ArrayVerifier;
+	lengthConsumer(consumer: (actual: NumberVerifier) => void): ArrayVerifier<E>;
+
+	/**
+	 * @returns a verifier for the <code>Array</code>
+	 * @throws TypeError if the actual value is not an <code>Array</code>
+	 * @deprecated returns this
+	 */
+	asArray(): ArrayVerifier<E>;
+
+	asArray<E>(): ArrayVerifier<E>;
+
+	/**
+	 * @param consumer - a function that accepts a {@link ArrayVerifier} for the actual value
+	 * @returns the updated verifier
+	 * @throws TypeError if <code>consumer</code> is not set.
+	 * If the actual value is not an <code>Array</code>.
+	 */
+	asArrayConsumer(consumer: (actual: ArrayVerifier<E>) => void): ArrayVerifier<E>;
+
+	asArrayConsumer<E>(consumer: (actual: ArrayVerifier<E>) => void): ArrayVerifier<E>;
 
 	/**
 	 * Verifies the Set representation of the array.
 	 *
 	 * @returns a <code>Set</code> verifier
 	 */
-	asSet(): SetVerifier;
+	asSet(): SetVerifier<E>;
+
+	asSet<E>(): SetVerifier<E>;
 
 	/**
 	 * @param consumer - a function that accepts a {@link SetVerifier} for the Set representation of the array
 	 * @returns the updated verifier
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	asSetConsumer(consumer: (actual: SetVerifier) => void): ArrayVerifier;
+	asSetConsumer(consumer: (actual: SetVerifier<E>) => void): ArrayVerifier<E>;
 
-	getActual(): unknown[];
+	asSetConsumer<E>(consumer: (actual: SetVerifier<E>) => void): ArrayVerifier<E>;
+
+	getActual(): E[];
 }
 
 export {type ArrayVerifier};

--- a/src/BooleanValidator.mts
+++ b/src/BooleanValidator.mts
@@ -10,7 +10,7 @@ import type {ExtensibleObjectValidator} from "./internal/internal.mjs";
  *
  * All methods (except those found in {@link ObjectValidator}) imply {@link isNotNull}.
  */
-interface BooleanValidator extends ExtensibleObjectValidator<BooleanValidator>
+interface BooleanValidator extends ExtensibleObjectValidator<BooleanValidator, boolean>
 {
 	/**
 	 * Ensures that the actual value is true.
@@ -26,7 +26,7 @@ interface BooleanValidator extends ExtensibleObjectValidator<BooleanValidator>
 	 */
 	isFalse(): BooleanValidator;
 
-	getActual(): boolean | void;
+	getActual(): boolean | undefined;
 }
 
 export {type BooleanValidator};

--- a/src/BooleanVerifier.mts
+++ b/src/BooleanVerifier.mts
@@ -5,7 +5,7 @@ import type {ExtensibleObjectVerifier} from "./internal/internal.mjs";
  * <p>
  * All methods (except those found in {@link ObjectVerifier}) imply {@link isNotNull}.
  */
-interface BooleanVerifier extends ExtensibleObjectVerifier<BooleanVerifier>
+interface BooleanVerifier extends ExtensibleObjectVerifier<BooleanVerifier, boolean>
 {
 	/**
 	 * Ensures that the actual value is true.

--- a/src/ClassValidator.mts
+++ b/src/ClassValidator.mts
@@ -10,7 +10,8 @@ import type {ExtensibleObjectValidator} from "./internal/internal.mjs";
  *
  * All methods (except those found in {@link ObjectValidator}) imply {@link isNotNull}.
  */
-interface ClassValidator extends ExtensibleObjectValidator<ClassValidator>
+// eslint-disable-next-line @typescript-eslint/ban-types
+interface ClassValidator extends ExtensibleObjectValidator<ClassValidator, Function>
 {
 	/**
 	 * Ensures that the actual value is the specified type, or a subtype.
@@ -31,7 +32,7 @@ interface ClassValidator extends ExtensibleObjectValidator<ClassValidator>
 	isSubtypeOf(type: Function): ClassValidator;
 
 	// eslint-disable-next-line @typescript-eslint/ban-types
-	getActual(): Function | void;
+	getActual(): Function | undefined;
 }
 
 export {type ClassValidator};

--- a/src/ClassVerifier.mts
+++ b/src/ClassVerifier.mts
@@ -5,7 +5,8 @@ import type {ObjectVerifier} from "./internal/internal.mjs";
  * <p>
  * All methods (except those found in {@link ObjectVerifier}) imply {@link isNotNull}.
  */
-interface ClassVerifier extends ObjectVerifier
+// eslint-disable-next-line @typescript-eslint/ban-types
+interface ClassVerifier extends ObjectVerifier<Function>
 {
 	/**
 	 * Ensures that the actual value is the specified type, or a super-type.

--- a/src/DefaultRequirements.mts
+++ b/src/DefaultRequirements.mts
@@ -1,29 +1,120 @@
 import type {
 	GlobalConfiguration,
 	ObjectValidator,
-	ObjectVerifier
+	ObjectVerifier,
+	StringValidator,
+	NumberValidator,
+	ClassValidator,
+	ArrayValidator,
+	SetValidator,
+	MapValidator,
+	StringVerifier,
+	NumberVerifier,
+	ClassVerifier,
+	ArrayVerifier,
+	SetVerifier,
+	MapVerifier
 } from "./internal/internal.mjs";
-import {Requirements} from "./internal/internal.mjs";
+import {
+	Requirements,
+	Objects,
+	ArrayValidatorImpl,
+	Pluralizer,
+	SetValidatorImpl,
+	ClassValidatorImpl,
+	ObjectValidatorImpl,
+	Configuration,
+	MainGlobalConfiguration,
+	ArrayVerifierImpl,
+	SetVerifierImpl,
+	MapVerifierImpl,
+	MapValidatorImpl,
+	ClassVerifierImpl,
+	ObjectVerifierImpl
+} from "./internal/internal.mjs";
 
 const typedocWorkaround: null | GlobalConfiguration = null;
 // noinspection PointlessBooleanExpressionJS
 if (typedocWorkaround !== null)
 	console.log("WORKAROUND: https://github.com/microsoft/tsdoc/issues/348");
 
-const delegate = new Requirements();
-
 /**
  * Verifies the requirements of an object.
  *
+ * @typeParam T - the type the actual value
  * @param actual - the actual value
  * @param name - the name of the value
  * @returns a verifier
  * @throws TypeError  if <code>name</code> is null
  * @throws RangeError if <code>name</code> is empty
  */
-function requireThat(actual: unknown, name: string): ObjectVerifier
+function requireThat(actual: string, name: string): StringVerifier;
+function requireThat(actual: number, name: string): NumberVerifier;
+function requireThat(actual: null, name: string): ObjectVerifier<null>;
+// eslint-disable-next-line @typescript-eslint/ban-types
+function requireThat(actual: Function, name: string): ClassVerifier;
+function requireThat<E>(actual: Array<E>, name: string): ArrayVerifier<E>;
+function requireThat<E>(actual: Set<E>, name: string): SetVerifier<E>;
+function requireThat<K, V>(actual: Map<K, V>, name: string): MapVerifier<K, V>;
+function requireThat<T>(actual: T, name: string): ObjectVerifier<T>;
+// eslint-disable-next-line @typescript-eslint/ban-types
+function requireThat<T extends string | number | Function | Array<E> | Set<E> | Map<K, V>, E, K, V>
+(actual: T, name: string): StringVerifier | NumberVerifier | ClassVerifier | ArrayVerifier<E> | SetVerifier<E> | MapVerifier<K, V> | ObjectVerifier<T>
 {
-	return delegate.requireThat(actual, name);
+	Objects.verifyName(name, "name");
+	const config = new Configuration(MainGlobalConfiguration.INSTANCE);
+	const typeOfActual = Objects.getTypeInfo(actual);
+	if (typeOfActual.type === "array")
+		return new ArrayVerifierImpl<E>(new ArrayValidatorImpl<E>(config, actual as E[], name, Pluralizer.ELEMENT, []));
+	if (typeOfActual.type === "object" && typeOfActual.name === "Set")
+		return new SetVerifierImpl<E>(new SetValidatorImpl<E>(config, actual as Set<E>, name, []));
+	if (typeOfActual.type === "object" && typeOfActual.name === "Map")
+		return new MapVerifierImpl<K, V>(new MapValidatorImpl<K, V>(config, actual as Map<K, V>, name, []));
+	if (typeOfActual.type === "class")
+	{
+		// eslint-disable-next-line @typescript-eslint/ban-types
+		return new ClassVerifierImpl(new ClassValidatorImpl(config, actual as Function, name, []));
+	}
+	return new ObjectVerifierImpl(new ObjectValidatorImpl(config, actual, name, []));
+}
+
+/**
+ * Validates the requirements of an object.
+ *
+ * @typeParam T - the type the actual value
+ * @param actual - the actual value
+ * @param name - the name of the value
+ * @returns a validator
+ * @throws TypeError  if <code>name</code> is null
+ * @throws RangeError if <code>name</code> is empty
+ * @see {@link GlobalConfiguration.assertionsAreEnabled | GlobalConfiguration.assertionsAreEnabled}
+ */
+function validateThat(actual: string, name: string): StringValidator;
+function validateThat(actual: number, name: string): NumberValidator;
+function validateThat(actual: null, name: string): ObjectValidator<null>;
+// eslint-disable-next-line @typescript-eslint/ban-types
+function validateThat(actual: Function, name: string): ClassValidator;
+function validateThat<E>(actual: Array<E>, name: string): ArrayValidator<E>;
+function validateThat<E>(actual: Set<E>, name: string): SetValidator<E>;
+function validateThat<K, V>(actual: Map<K, V>, name: string): MapValidator<K, V>;
+function validateThat<T>(actual: T, name: string): ObjectValidator<T>;
+// eslint-disable-next-line @typescript-eslint/ban-types
+function validateThat<T extends string | number | Function | Array<E> | Set<E> | Map<K, V>, E, K, V>
+(actual: T, name: string): StringValidator | NumberValidator | ClassValidator | ArrayValidator<E> | SetValidator<E> | MapValidator<K, V> | ObjectValidator<T>
+{
+	Objects.verifyName(name, "name");
+	const config = new Configuration(MainGlobalConfiguration.INSTANCE);
+	const typeOfActual = Objects.getTypeInfo(actual);
+	if (typeOfActual.type === "array")
+		return new ArrayValidatorImpl<E>(config, actual as E[], name, Pluralizer.ELEMENT, []);
+	if (typeOfActual.type === "object" && typeOfActual.name === "Set")
+		return new SetValidatorImpl<E>(config, actual as Set<E>, name, []);
+	if (typeOfActual.type === "class")
+	{
+		// eslint-disable-next-line @typescript-eslint/ban-types
+		return new ClassValidatorImpl(config, actual as Function, name, []);
+	}
+	return new ObjectValidatorImpl(config, actual, name, []);
 }
 
 /**
@@ -40,7 +131,10 @@ function requireThat(actual: unknown, name: string): ObjectVerifier
  */
 function assertThat(requirements: (requirements: Requirements) => void)
 {
-	delegate.assertThat(requirements);
+	Objects.requireThatValueIsDefinedAndNotNull(requirements, "requirements");
+	const config = new Configuration(MainGlobalConfiguration.INSTANCE);
+	if (config.assertionsAreEnabled())
+		requirements(new Requirements());
 }
 
 /**
@@ -58,28 +152,17 @@ function assertThat(requirements: (requirements: Requirements) => void)
  */
 function assertThatAndReturn(requirements: (requirements: Requirements) => void)
 {
-	return delegate.assertThatAndReturn(requirements);
-}
-
-/**
- * Validates the requirements of an object.
- *
- * @param actual - the actual value
- * @param name - the name of the value
- * @returns a validator
- * @throws TypeError  if <code>name</code> is null
- * @throws RangeError if <code>name</code> is empty
- * @see {@link GlobalConfiguration.assertionsAreEnabled | GlobalConfiguration.assertionsAreEnabled}
- */
-function validateThat(actual: unknown, name: string): ObjectValidator
-{
-	return delegate.validateThat(actual, name);
+	Objects.requireThatValueIsDefinedAndNotNull(requirements, "requirements");
+	const config = new Configuration(MainGlobalConfiguration.INSTANCE);
+	if (config.assertionsAreEnabled())
+		return requirements(new Requirements());
+	return undefined;
 }
 
 export
 {
 	requireThat,
+	validateThat,
 	assertThat,
-	assertThatAndReturn,
-	validateThat
+	assertThatAndReturn
 };

--- a/src/InetAddressValidator.mts
+++ b/src/InetAddressValidator.mts
@@ -10,7 +10,7 @@ import type {ExtensibleObjectValidator} from "./internal/internal.mjs";
  *
  * All methods (except those found in {@link ObjectValidator}) imply {@link isNotNull}.
  */
-interface InetAddressValidator extends ExtensibleObjectValidator<InetAddressValidator>
+interface InetAddressValidator extends ExtensibleObjectValidator<InetAddressValidator, string>
 {
 	/**
 	 * Ensures that the actual value is an IP v4 address.
@@ -34,7 +34,7 @@ interface InetAddressValidator extends ExtensibleObjectValidator<InetAddressVali
 	 */
 	isHostname(): InetAddressValidator;
 
-	getActual(): string | void;
+	getActual(): string | undefined;
 }
 
 export {type InetAddressValidator};

--- a/src/InetAddressVerifier.mts
+++ b/src/InetAddressVerifier.mts
@@ -5,7 +5,7 @@ import type {ObjectVerifier} from "./internal/internal.mjs";
  * <p>
  * All methods (except those found in {@link ObjectVerifier}) imply {@link isNotNull}.
  */
-interface InetAddressVerifier extends ObjectVerifier
+interface InetAddressVerifier extends ObjectVerifier<string>
 {
 	/**
 	 * Ensures that the actual value is an IP v4 address.

--- a/src/MapValidator.mts
+++ b/src/MapValidator.mts
@@ -13,52 +13,55 @@ import type {
  * exceptions.
  *
  * All methods (except those found in {@link ObjectValidator}) imply {@link isNotNull}.
+ *
+ * @typeParam K - the type the map's keys
+ * @typeParam V - the type the map's values
  */
-interface MapValidator extends ExtensibleObjectValidator<MapValidator>
+interface MapValidator<K, V> extends ExtensibleObjectValidator<MapValidator<K, V>, Map<K, V>>
 {
 	/**
 	 * Ensures that value does not contain any entries
 	 *
 	 * @returns the updated validator
 	 */
-	isEmpty(): MapValidator;
+	isEmpty(): MapValidator<K, V>;
 
 	/**
 	 * Ensures that value contains at least one entry.
 	 *
 	 * @returns the updated validator
 	 */
-	isNotEmpty(): MapValidator;
+	isNotEmpty(): MapValidator<K, V>;
 
 	/**
 	 * @returns a validator for the Map's keys
 	 */
-	keys(): ArrayValidator;
+	keys(): ArrayValidator<K>;
 
 	/**
 	 * @param consumer - a function that accepts an {@link ArrayValidator} for the Map's keys
 	 * @returns the updated validator
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	keysConsumer(consumer: (actual: ArrayValidator) => void): MapValidator;
+	keysConsumer(consumer: (actual: ArrayValidator<K>) => void): MapValidator<K, V>;
 
 	/**
 	 * @returns a validator for the Map's values
 	 */
-	values(): ArrayValidator;
+	values(): ArrayValidator<V>;
 
 	/**
 	 * @param consumer - a function that accepts an {@link ArrayValidator} for the Map's values
 	 * @returns the updated validator
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	valuesConsumer(consumer: (actual: ArrayValidator) => void): MapValidator;
+	valuesConsumer(consumer: (actual: ArrayValidator<V>) => void): MapValidator<K, V>;
 
 	/**
 	 * @returns validator for the Map's entries (an array of
 	 *   <code>[key, value]</code> for each element in the Map)
 	 */
-	entries(): ArrayValidator;
+	entries(): ArrayValidator<[K, V]>;
 
 	/**
 	 * @param consumer - a function that accepts an {@link ArrayValidator} for the Map's entries (an
@@ -66,7 +69,7 @@ interface MapValidator extends ExtensibleObjectValidator<MapValidator>
 	 * @returns the updated validator
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	entriesConsumer(consumer: (actual: ArrayValidator) => void): MapValidator;
+	entriesConsumer(consumer: (actual: ArrayValidator<[K, V]>) => void): MapValidator<K, V>;
 
 	/**
 	 * @returns a validator for the number of entries this Map contains
@@ -79,9 +82,27 @@ interface MapValidator extends ExtensibleObjectValidator<MapValidator>
 	 * @returns the updated validator
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	sizeConsumer(consumer: (actual: NumberValidator) => void): MapValidator;
+	sizeConsumer(consumer: (actual: NumberValidator) => void): MapValidator<K, V>;
 
-	getActual(): Map<unknown, unknown> | void;
+	/**
+	 * @returns a validator for the <code>Map</code>
+	 * @deprecated returns this
+	 */
+	asMap(): MapValidator<K, V>;
+
+	asMap<K, V>(): MapValidator<K, V>;
+
+	/**
+	 * @param consumer - a function that accepts a {@link MapValidator} for the actual value
+	 * @returns the updated validator
+	 * @throws TypeError if <code>consumer</code> is not set.
+	 * If the actual value is not a <code>Map</code>.
+	 */
+	asMapConsumer(consumer: (input: MapValidator<K, V>) => void): MapValidator<K, V>;
+
+	asMapConsumer<K, V>(consumer: (input: MapValidator<K, V>) => void): MapValidator<K, V>;
+
+	getActual(): Map<K, V> | undefined;
 }
 
 export {type MapValidator};

--- a/src/MapVerifier.mts
+++ b/src/MapVerifier.mts
@@ -8,8 +8,11 @@ import type {
  * Verifies the requirements of a <code>Map</code>.
  * <p>
  * All methods (except those found in {@link ObjectVerifier}) imply {@link isNotNull}.
+ *
+ * @typeParam K - the type the map's keys
+ * @typeParam V - the type the map's values
  */
-interface MapVerifier extends ObjectVerifier
+interface MapVerifier<K, V> extends ObjectVerifier<Map<K, V>>
 {
 	/**
 	 * Ensures that value does not contain any entries
@@ -17,7 +20,7 @@ interface MapVerifier extends ObjectVerifier
 	 * @returns the updated verifier
 	 * @throws TypeError if the value contains any entries
 	 */
-	isEmpty(): MapVerifier;
+	isEmpty(): MapVerifier<K, V>;
 
 	/**
 	 * Ensures that value contains at least one entry.
@@ -25,37 +28,37 @@ interface MapVerifier extends ObjectVerifier
 	 * @returns the updated verifier
 	 * @throws TypeError if the value does not contain any entries
 	 */
-	isNotEmpty(): MapVerifier;
+	isNotEmpty(): MapVerifier<K, V>;
 
 	/**
 	 * @returns a verifier for the Map's keys
 	 */
-	keys(): ArrayVerifier;
+	keys(): ArrayVerifier<K>;
 
 	/**
 	 * @param consumer - a function that accepts an {@link ArrayVerifier} for the Map's keys
 	 * @returns the updated verifier
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	keysConsumer(consumer: (actual: ArrayVerifier) => void): MapVerifier;
+	keysConsumer(consumer: (actual: ArrayVerifier<K>) => void): MapVerifier<K, V>;
 
 	/**
 	 * @returns a verifier for the Map's values
 	 */
-	values(): ArrayVerifier;
+	values(): ArrayVerifier<V>;
 
 	/**
 	 * @param consumer - a function that accepts an {@link ArrayVerifier} for the Map's values
 	 * @returns the updated verifier
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	valuesConsumer(consumer: (actual: ArrayVerifier) => void): MapVerifier;
+	valuesConsumer(consumer: (actual: ArrayVerifier<V>) => void): MapVerifier<K, V>;
 
 	/**
 	 * @returns a verifier for the Map's entries (an array of <code>[key, value]</code> for
 	 *   each element in the Map)
 	 */
-	entries(): ArrayVerifier;
+	entries(): ArrayVerifier<[K, V]>;
 
 	/**
 	 * @param consumer - a function that accepts an {@link ArrayVerifier} for the Map's entries (an
@@ -63,7 +66,7 @@ interface MapVerifier extends ObjectVerifier
 	 * @returns the updated verifier
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	entriesConsumer(consumer: (actual: ArrayVerifier) => void): MapVerifier;
+	entriesConsumer(consumer: (actual: ArrayVerifier<[K, V]>) => void): MapVerifier<K, V>;
 
 	/**
 	 * @returns a verifier for the number of entries this Map contains
@@ -76,9 +79,27 @@ interface MapVerifier extends ObjectVerifier
 	 * @returns the updated verifier
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	sizeConsumer(consumer: (actual: NumberVerifier) => void): MapVerifier;
+	sizeConsumer(consumer: (actual: NumberVerifier) => void): MapVerifier<K, V>;
 
-	getActual(): Map<unknown, unknown>;
+	/**
+	 * @returns a verifier for the <code>Map</code>
+	 * @deprecated returns this
+	 */
+	asMap(): MapVerifier<K, V>;
+
+	asMap<K, V>(): MapVerifier<K, V>;
+
+	/**
+	 * @param consumer - a function that accepts a {@link MapVerifier} for the actual value
+	 * @returns the updated verifier
+	 * @throws TypeError if <code>consumer</code> is not set.
+	 * If the actual value is not a <code>Map</code>.
+	 */
+	asMapConsumer(consumer: (input: MapVerifier<K, V>) => void): MapVerifier<K, V>;
+
+	asMapConsumer<K, V>(consumer: (input: MapVerifier<K, V>) => void): MapVerifier<K, V>;
+
+	getActual(): Map<K, V>;
 }
 
 export {type MapVerifier};

--- a/src/NumberValidator.mts
+++ b/src/NumberValidator.mts
@@ -3,7 +3,7 @@ import type {
 	ExtensibleObjectValidator
 } from "./internal/internal.mjs";
 
-const typedocWorkaround: null | ExtensibleObjectValidator<void> = null;
+const typedocWorkaround: null | ExtensibleObjectValidator<void, void> = null;
 // noinspection PointlessBooleanExpressionJS
 if (typedocWorkaround !== null)
 	console.log("WORKAROUND: https://github.com/microsoft/tsdoc/issues/348");

--- a/src/ObjectValidator.mts
+++ b/src/ObjectValidator.mts
@@ -7,9 +7,11 @@ import type {ExtensibleObjectValidator} from "./internal/internal.mjs";
  * Validators return validation failures through the
  * {@link ExtensibleObjectValidator.getFailures | getFailures()} method, while Verifiers throw them as
  * exceptions.
+ *
+ * @typeParam T - the type the actual value
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface ObjectValidator extends ExtensibleObjectValidator<ObjectValidator>
+interface ObjectValidator<T> extends ExtensibleObjectValidator<ObjectValidator<T>, T>
 {
 }
 

--- a/src/ObjectVerifier.mts
+++ b/src/ObjectVerifier.mts
@@ -2,9 +2,11 @@ import type {ExtensibleObjectVerifier} from "./internal/internal.mjs";
 
 /**
  * Verifies the requirements of an object.
+ *
+ * @typeParam T - the type the actual value
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
-interface ObjectVerifier extends ExtensibleObjectVerifier<ObjectVerifier>
+interface ObjectVerifier<T> extends ExtensibleObjectVerifier<ObjectVerifier<T>, T>
 {
 }
 

--- a/src/SetValidator.mts
+++ b/src/SetValidator.mts
@@ -13,22 +13,24 @@ import type {
  * exceptions.
  *
  * All methods (except those found in {@link ObjectValidator}) imply {@link isNotNull}.
+ *
+ * @typeParam E - the type the array elements
  */
-interface SetValidator extends ExtensibleObjectValidator<SetValidator>
+interface SetValidator<E> extends ExtensibleObjectValidator<SetValidator<E>, Set<E>>
 {
 	/**
 	 * Ensures that value does not contain any elements.
 	 *
 	 * @returns the updated validator
 	 */
-	isEmpty(): SetValidator;
+	isEmpty(): SetValidator<E>;
 
 	/**
 	 * Ensures that value contains at least one element.
 	 *
 	 * @returns the updated validator
 	 */
-	isNotEmpty(): SetValidator;
+	isNotEmpty(): SetValidator<E>;
 
 	/**
 	 * Ensures that the actual value contains an entry.
@@ -39,7 +41,7 @@ interface SetValidator extends ExtensibleObjectValidator<SetValidator>
 	 * @throws TypeError if <code>name</code> is null
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	contains(expected: unknown, name?: string): SetValidator;
+	contains(expected: E, name?: string): SetValidator<E>;
 
 	/**
 	 * Ensures that the actual value contains exactly the same elements as the expected value; nothing less,
@@ -52,7 +54,7 @@ interface SetValidator extends ExtensibleObjectValidator<SetValidator>
 	 * If <code>expected</code> is not an <code>Array</code> or <code>Set</code>.
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	containsExactly(expected: unknown[] | Set<unknown>, name?: string): SetValidator;
+	containsExactly(expected: E[] | Set<E>, name?: string): SetValidator<E>;
 
 	/**
 	 * Ensures that the actual value contains any of the elements in the expected value.
@@ -64,7 +66,7 @@ interface SetValidator extends ExtensibleObjectValidator<SetValidator>
 	 * If <code>expected</code> is not an <code>Array</code> or <code>Set</code>.
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	containsAny(expected: unknown[] | Set<unknown>, name?: string): SetValidator;
+	containsAny(expected: E[] | Set<E>, name?: string): SetValidator<E>;
 
 	/**
 	 * Ensures that the actual value contains all the elements in the expected value.
@@ -76,7 +78,7 @@ interface SetValidator extends ExtensibleObjectValidator<SetValidator>
 	 * If <code>expected</code> is not an <code>Array</code> or <code>Set</code>.
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	containsAll(expected: unknown[] | Set<unknown>, name?: string): SetValidator;
+	containsAll(expected: E[] | Set<E>, name?: string): SetValidator<E>;
 
 	/**
 	 * Ensures that the actual value does not contain an entry.
@@ -87,7 +89,7 @@ interface SetValidator extends ExtensibleObjectValidator<SetValidator>
 	 * @throws TypeError if <code>name</code> is null
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	doesNotContain(entry: unknown, name?: string): SetValidator;
+	doesNotContain(entry: E, name?: string): SetValidator<E>;
 
 	/**
 	 * Ensures that the actual value does not contain any of the specified elements.
@@ -99,7 +101,7 @@ interface SetValidator extends ExtensibleObjectValidator<SetValidator>
 	 * If <code>elements</code> is not an <code>Array</code> or <code>Set</code>.
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	doesNotContainAny(elements: unknown[] | Set<unknown>, name?: string): SetValidator;
+	doesNotContainAny(elements: E[] | Set<E>, name?: string): SetValidator<E>;
 
 	/**
 	 * Ensures that the array does not contain all the specified elements.
@@ -111,7 +113,7 @@ interface SetValidator extends ExtensibleObjectValidator<SetValidator>
 	 * If <code>elements</code> is not an <code>Array</code> or <code>Set</code>.
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	doesNotContainAll(elements: unknown[] | Set<unknown>, name?: string): SetValidator;
+	doesNotContainAll(elements: E[] | Set<E>, name?: string): SetValidator<E>;
 
 	/**
 	 * @returns a validator for the Set's size
@@ -123,21 +125,43 @@ interface SetValidator extends ExtensibleObjectValidator<SetValidator>
 	 * @returns the updated validator
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	sizeConsumer(consumer: (actual: NumberValidator) => void): SetValidator;
+	sizeConsumer(consumer: (actual: NumberValidator) => void): SetValidator<E>;
 
 	/**
 	 * @returns a validator for the Set's elements
 	 */
-	asArray(): ArrayValidator;
+	asArray(): ArrayValidator<E>;
+
+	asArray<E>(): ArrayValidator<E>;
+
 
 	/**
 	 * @param consumer - a function that accepts an {@link ArrayValidator} for the Set's elements
 	 * @returns the updated validator
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	asArrayConsumer(consumer: (actual: ArrayValidator) => void): SetValidator;
+	asArrayConsumer(consumer: (actual: ArrayValidator<E>) => void): SetValidator<E>;
 
-	getActual(): void | Set<unknown>;
+	asArrayConsumer<S, E>(consumer: (input: ArrayValidator<E>) => void): S;
+
+	/**
+	 * @returns a validator for the <code>Set</code>
+	 * @deprecated returns this
+	 */
+	asSet(): SetValidator<E>;
+
+	asSet<E>(): SetValidator<E>;
+
+	/**
+	 * @param consumer - a function that accepts a {@link SetValidator} for the actual value
+	 * @returns the updated validator
+	 * @throws TypeError if <code>consumer</code> is not set
+	 */
+	asSetConsumer(consumer: (actual: SetValidator<E>) => void): SetValidator<E>;
+
+	asSetConsumer<E>(consumer: (actual: SetValidator<E>) => void): SetValidator<E>;
+
+	getActual(): Set<E> | undefined;
 }
 
 export {type SetValidator};

--- a/src/SetVerifier.mts
+++ b/src/SetVerifier.mts
@@ -8,8 +8,10 @@ import type {
  * Verifies the requirements of a <code>Set</code>.
  * <p>
  * All methods (except those found in {@link ObjectVerifier}) imply {@link isNotNull}.
+ *
+ * @typeParam E - the type the array elements
  */
-interface SetVerifier extends ObjectVerifier
+interface SetVerifier<E> extends ObjectVerifier<Set<E>>
 {
 	/**
 	 * Ensures that value does not contain any elements.
@@ -17,7 +19,7 @@ interface SetVerifier extends ObjectVerifier
 	 * @returns the updated verifier
 	 * @throws TypeError if the value contains at least one element
 	 */
-	isEmpty(): SetVerifier;
+	isEmpty(): SetVerifier<E>;
 
 	/**
 	 * Ensures that value contains at least one element.
@@ -25,7 +27,7 @@ interface SetVerifier extends ObjectVerifier
 	 * @returns the updated verifier
 	 * @throws TypeError if the value does not contain any elements
 	 */
-	isNotEmpty(): SetVerifier;
+	isNotEmpty(): SetVerifier<E>;
 
 	/**
 	 * Ensures that the actual value contains an entry.
@@ -37,7 +39,7 @@ interface SetVerifier extends ObjectVerifier
 	 * @throws RangeError if <code>name</code> is empty.
 	 * If the Set does not contain <code>expected</code>.
 	 */
-	contains(expected: unknown, name?: string): SetVerifier;
+	contains(expected: E, name?: string): SetVerifier<E>;
 
 	/**
 	 * Ensures that the actual value contains exactly the same elements as the expected value; nothing less,
@@ -52,7 +54,7 @@ interface SetVerifier extends ObjectVerifier
 	 * If the actual value is missing any elements in <code>expected</code>.
 	 * If the actual value contains elements not found in <code>expected</code>.
 	 */
-	containsExactly(expected: unknown[] | Set<unknown>, name?: string): SetVerifier;
+	containsExactly(expected: E[] | Set<E>, name?: string): SetVerifier<E>;
 
 	/**
 	 * Ensures that the actual value contains any of the elements in the expected value.
@@ -66,7 +68,7 @@ interface SetVerifier extends ObjectVerifier
 	 * If the actual value is missing any elements in <code>expected</code>.
 	 * If the actual value contains elements not found in <code>expected</code>.
 	 */
-	containsAny(expected: unknown[] | Set<unknown>, name?: string): SetVerifier;
+	containsAny(expected: E[] | Set<E>, name?: string): SetVerifier<E>;
 
 	/**
 	 * Ensures that the actual value contains all the elements in the expected value.
@@ -79,7 +81,7 @@ interface SetVerifier extends ObjectVerifier
 	 * @throws RangeError if <code>name</code> is empty.
 	 * If the actual value does not contain all of <code>expected</code>.
 	 */
-	containsAll(expected: unknown[] | Set<unknown>, name?: string): SetVerifier;
+	containsAll(expected: E[] | Set<E>, name?: string): SetVerifier<E>;
 
 	/**
 	 * Ensures that the actual value does not contain an entry.
@@ -91,7 +93,7 @@ interface SetVerifier extends ObjectVerifier
 	 * @throws RangeError if <code>name</code> is empty.
 	 * If the actual value contains <code>entry</code>.
 	 */
-	doesNotContain(entry: unknown, name?: string): SetVerifier;
+	doesNotContain(entry: E, name?: string): SetVerifier<E>;
 
 	/**
 	 * Ensures that the actual value does not contain any of the specified elements.
@@ -104,7 +106,7 @@ interface SetVerifier extends ObjectVerifier
 	 * @throws RangeError if <code>name</code> is empty.
 	 * If the array contains any of <code>elements</code>.
 	 */
-	doesNotContainAny(elements: unknown[] | Set<unknown>, name?: string): SetVerifier;
+	doesNotContainAny(elements: E[] | Set<E>, name?: string): SetVerifier<E>;
 
 	/**
 	 * Ensures that the array does not contain all the specified elements.
@@ -117,7 +119,7 @@ interface SetVerifier extends ObjectVerifier
 	 * @throws RangeError if <code>name</code> is empty.
 	 * If the actual value contains all of <code>elements</code>.
 	 */
-	doesNotContainAll(elements: unknown[] | Set<unknown>, name?: string): SetVerifier;
+	doesNotContainAll(elements: E[] | Set<E>, name?: string): SetVerifier<E>;
 
 	/**
 	 * @returns a verifier for the Set's size
@@ -129,21 +131,42 @@ interface SetVerifier extends ObjectVerifier
 	 * @returns the updated verifier
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	sizeConsumer(consumer: (actual: NumberVerifier) => void): SetVerifier;
+	sizeConsumer(consumer: (actual: NumberVerifier) => void): SetVerifier<E>;
 
 	/**
 	 * @returns a verifier for the Set's elements
 	 */
-	asArray(): ArrayVerifier;
+	asArray<E>(): ArrayVerifier<E>;
+
+	asArray(): ArrayVerifier<E>;
 
 	/**
 	 * @param consumer - a function that accepts an {@link ArrayVerifier} for the Set's elements
 	 * @returns the updated verifier
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	asArrayConsumer(consumer: (actual: ArrayVerifier) => void): SetVerifier;
+	asArrayConsumer<S, E>(consumer: (actual: ArrayVerifier<E>) => void): S;
 
-	getActual(): Set<unknown>;
+	asArrayConsumer(consumer: (actual: ArrayVerifier<E>) => void): SetVerifier<E>;
+
+	/**
+	 * @returns a verifier for the <code>Set</code>
+	 * @deprecated returns this
+	 */
+	asSet(): SetVerifier<E>;
+
+	asSet<E>(): SetVerifier<E>;
+
+	/**
+	 * @param consumer - a function that accepts a {@link SetVerifier} for the actual value
+	 * @returns the updated verifier
+	 * @throws TypeError if <code>consumer</code> is not set
+	 */
+	asSetConsumer(consumer: (actual: SetVerifier<E>) => void): SetVerifier<E>;
+
+	asSetConsumer<E>(consumer: (actual: SetVerifier<E>) => void): SetVerifier<E>;
+
+	getActual(): Set<E>;
 }
 
 export {type SetVerifier};

--- a/src/StringValidator.mts
+++ b/src/StringValidator.mts
@@ -14,7 +14,7 @@ import type {
  * All methods (except for {@link asString} and those found in {@link ObjectValidator}) imply
  * {@link isNotNull}.
  */
-interface StringValidator extends ExtensibleObjectValidator<StringValidator>
+interface StringValidator extends ExtensibleObjectValidator<StringValidator, string>
 {
 	/**
 	 * Ensures that the actual value starts with a value.
@@ -127,7 +127,7 @@ interface StringValidator extends ExtensibleObjectValidator<StringValidator>
 	 */
 	asStringConsumer(consumer: (actual: StringValidator) => void): StringValidator;
 
-	getActual(): string | void;
+	getActual(): string | undefined;
 }
 
 export {type StringValidator};

--- a/src/StringVerifier.mts
+++ b/src/StringVerifier.mts
@@ -4,7 +4,7 @@ import type {
 	ObjectVerifier
 } from "./internal/internal.mjs";
 
-const typedocWorkaround: null | ExtensibleObjectValidator<void> = null;
+const typedocWorkaround: null | ExtensibleObjectValidator<void, void> = null;
 // noinspection PointlessBooleanExpressionJS
 if (typedocWorkaround !== null)
 	console.log("WORKAROUND: https://github.com/microsoft/tsdoc/issues/348");
@@ -20,7 +20,7 @@ if (typedocWorkaround !== null)
  * All methods (except for {@link asString} and those found in {@link ObjectValidator}) imply
  * {@link isNotNull}.
  */
-interface StringVerifier extends ObjectVerifier
+interface StringVerifier extends ObjectVerifier<string>
 {
 	/**
 	 * Ensures that the actual value starts with a value.

--- a/src/extension/ExtensibleNumberValidator.mts
+++ b/src/extension/ExtensibleNumberValidator.mts
@@ -7,7 +7,7 @@ import type {ExtensibleObjectValidator} from "../internal/internal.mjs";
  *
  * @typeParam S - the type of validator returned by the methods
  */
-interface ExtensibleNumberValidator<S> extends ExtensibleObjectValidator<S>
+interface ExtensibleNumberValidator<S> extends ExtensibleObjectValidator<S, number>
 {
 	/**
 	 * Ensures that the actual value is negative.
@@ -143,7 +143,7 @@ interface ExtensibleNumberValidator<S> extends ExtensibleObjectValidator<S>
 	 */
 	isNotFinite(): S;
 
-	getActual(): number | void;
+	getActual(): number | undefined;
 }
 
 export {type ExtensibleNumberValidator};

--- a/src/extension/ExtensibleNumberVerifier.mts
+++ b/src/extension/ExtensibleNumberVerifier.mts
@@ -7,7 +7,7 @@ import type {ExtensibleObjectVerifier} from "../internal/internal.mjs";
  *
  * @typeParam S - the type of validator returned by the methods
  */
-interface ExtensibleNumberVerifier<S> extends ExtensibleObjectVerifier<S>
+interface ExtensibleNumberVerifier<S> extends ExtensibleObjectVerifier<S, number>
 {
 	/**
 	 * Ensures that the actual value is negative.

--- a/src/extension/ExtensibleObjectValidator.mts
+++ b/src/extension/ExtensibleObjectValidator.mts
@@ -1,21 +1,22 @@
 import type {
-	ArrayValidator,
-	BooleanValidator,
-	ClassValidator,
-	InetAddressValidator,
-	MapValidator,
-	NumberValidator,
-	SetValidator,
 	StringValidator,
-	ValidationFailure
+	ValidationFailure,
+	BooleanValidator,
+	NumberValidator,
+	InetAddressValidator,
+	ClassValidator,
+	ArrayValidator,
+	SetValidator,
+	MapValidator
 } from "../internal/internal.mjs";
 
 /**
  * Validates the requirements of an object.
  *
  * @typeParam S - the type of validator returned by the methods
+ * @typeParam T - the type the actual value
  */
-interface ExtensibleObjectValidator<S>
+interface ExtensibleObjectValidator<S, T>
 {
 	/**
 	 * Ensures that the actual value is equal to a value.
@@ -26,7 +27,7 @@ interface ExtensibleObjectValidator<S>
 	 * @throws TypeError if <code>name</code> is null
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	isEqualTo(expected: unknown, name?: string): S;
+	isEqualTo(expected: T, name?: string): S;
 
 	/**
 	 * Ensures that the actual value is not equal to a value.
@@ -37,7 +38,7 @@ interface ExtensibleObjectValidator<S>
 	 * @throws TypeError if <code>name</code> is null
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	isNotEqualTo(value: unknown, name?: string): S;
+	isNotEqualTo(value: T, name?: string): S;
 
 	/**
 	 * Ensures that the actual value is a primitive. To check if the actual value is an object, use
@@ -119,9 +120,9 @@ interface ExtensibleObjectValidator<S>
 	/**
 	 * Returns the actual value.
 	 *
-	 * @returns the actual value
+	 * @returns undefined if the validation failed
 	 */
-	getActual(): unknown;
+	getActual(): T | undefined;
 
 	/**
 	 * @returns a validator for the object's string representation
@@ -134,19 +135,7 @@ interface ExtensibleObjectValidator<S>
 	 * @returns the updated validator
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	asStringConsumer(consumer: (actual: unknown) => StringValidator): S;
-
-	/**
-	 * @returns a validator for the <code>Array</code>
-	 */
-	asArray(): ArrayValidator;
-
-	/**
-	 * @param consumer - a function that accepts a {@link ArrayValidator} for the actual value
-	 * @returns the updated validator
-	 * @throws TypeError if <code>consumer</code> is not set
-	 */
-	asArrayConsumer(consumer: (input: ArrayValidator) => void): S;
+	asStringConsumer(consumer: (actual: StringValidator) => StringValidator): S;
 
 	/**
 	 * @returns a validator for the <code>boolean</code>
@@ -173,29 +162,49 @@ interface ExtensibleObjectValidator<S>
 	asNumberConsumer(consumer: (input: NumberValidator) => void): S;
 
 	/**
-	 * @returns a validator for the <code>Set</code>
+	 * @typeParam E - the type the array elements
+	 * @returns a validator for the <code>Array</code>
 	 */
-	asSet(): SetValidator;
+	asArray<E>(): ArrayValidator<E>;
 
 	/**
+	 * @typeParam E - the type the array elements
+	 * @param consumer - a function that accepts a {@link ArrayValidator} for the actual value
+	 * @returns the updated validator
+	 * @throws TypeError if <code>consumer</code> is not set
+	 */
+	asArrayConsumer<E>(consumer: (input: ArrayValidator<E>) => void): S;
+
+	/**
+	 * @typeParam E - the type the set elements
+	 * @returns a validator for the <code>Set</code>
+	 */
+	asSet<E>(): SetValidator<E>;
+
+	/**
+	 * @typeParam E - the type the array elements
 	 * @param consumer - a function that accepts a {@link SetValidator} for the actual value
 	 * @returns the updated validator
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
-	asSetConsumer(consumer: (actual: SetValidator) => void): S;
+	asSetConsumer<E>(consumer: (actual: SetValidator<E>) => void): S;
 
 	/**
+	 * @typeParam K - the type the map's keys
+	 * @typeParam V - the type the map's values
 	 * @returns a validator for the <code>Map</code>
 	 */
-	asMap(): MapValidator;
+	asMap<K, V>(): MapValidator<K, V>;
 
 	/**
+	 * @typeParam K - the type the map's keys
+	 * @typeParam V - the type the map's values
 	 * @param consumer - a function that accepts a {@link MapValidator} for the actual value
 	 * @returns the updated validator
 	 * @throws TypeError if <code>consumer</code> is not set.
 	 * If the actual value is not a <code>Map</code>.
 	 */
-	asMapConsumer(consumer: (input: MapValidator) => void): S;
+	asMapConsumer<K, V>(consumer: (input: MapValidator<K, V>) => void): S;
 
 	/**
 	 * @returns a validator for the value's Internet address representation

--- a/src/extension/ExtensibleObjectVerifier.mts
+++ b/src/extension/ExtensibleObjectVerifier.mts
@@ -1,20 +1,21 @@
 import type {
-	ArrayVerifier,
+	StringVerifier,
 	BooleanVerifier,
-	ClassVerifier,
-	InetAddressVerifier,
-	MapVerifier,
 	NumberVerifier,
+	InetAddressVerifier,
+	ClassVerifier,
+	ArrayVerifier,
 	SetVerifier,
-	StringVerifier
+	MapVerifier
 } from "../internal/internal.mjs";
 
 /**
  * Verifies the requirements of an object.
  *
  * @typeParam S - the type of verifier returned by the methods
+ * @typeParam T - the type the actual value
  */
-interface ExtensibleObjectVerifier<S>
+interface ExtensibleObjectVerifier<S, T>
 {
 	/**
 	 * Ensures that the actual value is equal to a value.
@@ -26,7 +27,7 @@ interface ExtensibleObjectVerifier<S>
 	 * @throws RangeError if <code>name</code> is empty.
 	 * If the actual value is not equal to <code>expected</code>.
 	 */
-	isEqualTo(expected: unknown, name?: string): S;
+	isEqualTo(expected: T, name?: string): S;
 
 	/**
 	 * Throws an exception if the validation failed.
@@ -49,7 +50,7 @@ interface ExtensibleObjectVerifier<S>
 	 * @throws RangeError if <code>name</code> is empty.
 	 * If the actual value is equal to <code>value</code>.
 	 */
-	isNotEqualTo(value: unknown, name?: string): S;
+	isNotEqualTo(value: T, name?: string): S;
 
 	/**
 	 * Ensures that the actual value is a primitive. To check if the actual value is an object, use
@@ -138,7 +139,7 @@ interface ExtensibleObjectVerifier<S>
 	 *
 	 * @returns the actual value
 	 */
-	getActual(): unknown;
+	getActual(): T;
 
 	/**
 	 * @returns a verifier for the object's string representation
@@ -152,20 +153,6 @@ interface ExtensibleObjectVerifier<S>
 	 * @throws TypeError if <code>consumer</code> is not set
 	 */
 	asStringConsumer(consumer: (actual: StringVerifier) => void): S;
-
-	/**
-	 * @returns a verifier for the <code>Array</code>
-	 * @throws TypeError if the actual value is not an <code>Array</code>
-	 */
-	asArray(): ArrayVerifier;
-
-	/**
-	 * @param consumer - a function that accepts a {@link ArrayVerifier} for the actual value
-	 * @returns the updated verifier
-	 * @throws TypeError if <code>consumer</code> is not set.
-	 * If the actual value is not an <code>Array</code>.
-	 */
-	asArrayConsumer(consumer: (actual: ArrayVerifier) => void): S;
 
 	/**
 	 * @returns a verifier for the <code>boolean</code>
@@ -196,32 +183,54 @@ interface ExtensibleObjectVerifier<S>
 	asNumberConsumer(consumer: (actual: NumberVerifier) => void): S;
 
 	/**
+	 * @typeParam E - the type the array elements
+	 * @returns a verifier for the <code>Array</code>
+	 * @throws TypeError if the actual value is not an <code>Array</code>
+	 */
+	asArray<E>(): ArrayVerifier<E>;
+
+	/**
+	 * @typeParam E - the type the array elements
+	 * @param consumer - a function that accepts a {@link ArrayVerifier} for the actual value
+	 * @returns the updated verifier
+	 * @throws TypeError if <code>consumer</code> is not set.
+	 * If the actual value is not an <code>Array</code>.
+	 */
+	asArrayConsumer<E>(consumer: (actual: ArrayVerifier<E>) => void): S;
+
+	/**
+	 * @typeParam E - the type the set elements
 	 * @returns a verifier for the <code>Set</code>
 	 * @throws TypeError if the actual value is not a <code>Set</code>
 	 */
-	asSet(): SetVerifier;
+	asSet<E>(): SetVerifier<E>;
 
 	/**
+	 * @typeParam E - the type the set elements
 	 * @param consumer - a function that accepts a {@link SetVerifier} for the actual value
 	 * @returns the updated verifier
 	 * @throws TypeError if <code>consumer</code> is not set.
 	 * If the actual value is not a <code>Set</code>.
 	 */
-	asSetConsumer(consumer: (actual: SetVerifier) => void): S;
+	asSetConsumer<E>(consumer: (actual: SetVerifier<E>) => void): S;
 
 	/**
+	 * @typeParam K - the type the map's keys
+	 * @typeParam V - the type the map's values
 	 * @returns a verifier for the <code>Map</code>
 	 * @throws TypeError if the actual value is not a <code>Map</code>
 	 */
-	asMap(): MapVerifier;
+	asMap<K, V>(): MapVerifier<K, V>;
 
 	/**
+	 * @typeParam K - the type the map's keys
+	 * @typeParam V - the type the map's values
 	 * @param consumer - a function that accepts a {@link MapVerifier} for the actual value
 	 * @returns the updated verifier
 	 * @throws TypeError if <code>consumer</code> is not set.
 	 * If the actual value is not a <code>Map</code>.
 	 */
-	asMapConsumer(consumer: (actual: MapVerifier) => void): S;
+	asMapConsumer<K, V>(consumer: (actual: MapVerifier<K, V>) => void): S;
 
 	/**
 	 * @returns a verifier for the value's Internet address representation

--- a/src/index.mts
+++ b/src/index.mts
@@ -5,5 +5,9 @@ export
 	assertThatAndReturn,
 	validateThat
 } from "./DefaultRequirements.mjs";
-export {Requirements} from "./internal/internal.mjs";
-export {GlobalRequirements} from "./internal/internal.mjs";
+export {
+	Requirements,
+	GlobalRequirements,
+	Configuration,
+	TerminalEncoding
+} from "./internal/internal.mjs";

--- a/src/internal/ArrayValidatorImpl.mts
+++ b/src/internal/ArrayValidatorImpl.mts
@@ -16,11 +16,13 @@ import {
 
 /**
  * Default implementation of <code>ArrayValidator</code>.
+ *
+ * @typeParam T - the type the actual value
  */
-class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
-	implements ArrayValidator
+class ArrayValidatorImpl<E> extends AbstractObjectValidator<ArrayValidator<E>, E[]>
+	implements ArrayValidator<E>
 {
-	private readonly actualArray: void | unknown[];
+	private readonly actualArray: E[] | undefined;
 	private readonly pluralizer: Pluralizer;
 
 	/**
@@ -34,7 +36,7 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 	 * @throws TypeError if <code>configuration</code> or <code>name</code> are null or undefined
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	constructor(configuration: Configuration, actual: void | unknown[], name: string, pluralizer: Pluralizer,
+	constructor(configuration: Configuration, actual: E[] | undefined, name: string, pluralizer: Pluralizer,
 		failures: ValidationFailure[])
 	{
 		super(configuration, actual, name, failures);
@@ -52,9 +54,8 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			return this;
 
-
-		const actualAsNotVoid = this.actualArray as unknown[];
-		if (actualAsNotVoid.length > 0)
+		const actualAsDefined = this.actualArray as E[];
+		if (actualAsDefined.length > 0)
 		{
 			const failure = new ValidationFailure(this.config, RangeError, this.name + " must be empty").
 				addContext("Actual", this.actualArray);
@@ -68,9 +69,8 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			return this;
 
-
-		const actualAsNotVoid = this.actualArray as unknown[];
-		if (actualAsNotVoid.length === 0)
+		const actualAsDefined = this.actualArray as E[];
+		if (actualAsDefined.length === 0)
 		{
 			const failure = new ValidationFailure(this.config, RangeError, this.name + " may not be empty.");
 			this.failures.push(failure);
@@ -85,7 +85,7 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 	 * @param element - an element
 	 * @returns true if <code>arrays</code> contains the element
 	 */
-	private static arrayContainsElement(array: unknown[], element: unknown): boolean
+	private arrayContainsElement(array: E[], element: E): boolean
 	{
 		// indexOf(), includes() do not work for multidimensional arrays: http://stackoverflow.com/a/24943461/14731
 		for (let i = 0; i < array.length; ++i)
@@ -101,11 +101,11 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 	 * @param expected - an array of expected values
 	 * @returns true if <code>actual</code> contains any of the <code>expected</code> elements
 	 */
-	private static arrayContainsAny(array: unknown[], expected: unknown[]): boolean
+	private arrayContainsAny(array: E[], expected: E[]): boolean
 	{
 		for (const element of expected)
 		{
-			if (ArrayValidatorImpl.arrayContainsElement(array, element))
+			if (this.arrayContainsElement(array, element))
 				return true;
 		}
 		return false;
@@ -118,26 +118,25 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 	 * @param expected - an array of expected elements
 	 * @returns true if <code>actual</code> contains all the <code>expected</code> elements
 	 */
-	private static arrayContainsAll(array: unknown[], expected: unknown[]): boolean
+	private arrayContainsAll(array: E[], expected: E[]): boolean
 	{
 		for (const element of expected)
 		{
-			if (!ArrayValidatorImpl.arrayContainsElement(array, element))
+			if (!this.arrayContainsElement(array, element))
 				return false;
 		}
 		return true;
 	}
 
-	contains(element: unknown, name?: string): ArrayValidator
+	contains(element: E, name?: string): ArrayValidator<E>
 	{
 		if (typeof (name) !== "undefined")
 			Objects.requireThatStringIsNotEmpty(name, "name");
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			return this;
 
-
-		const actualAsNotVoid = this.actualArray as unknown[];
-		if (!ArrayValidatorImpl.arrayContainsElement(actualAsNotVoid, element))
+		const actualAsDefined = this.actualArray as E[];
+		if (!this.arrayContainsElement(actualAsDefined, element))
 		{
 			let failure;
 			if (name)
@@ -158,7 +157,7 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 		return this;
 	}
 
-	containsExactly(expected: unknown[], name?: string): ArrayValidator
+	containsExactly(expected: E[], name?: string): ArrayValidator<E>
 	{
 		if (typeof (name) !== "undefined")
 			Objects.requireThatStringIsNotEmpty(name, "name");
@@ -166,10 +165,9 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			return this;
 
-
-		const actualAsNotVoid = this.actualArray as unknown[];
+		const actualAsDefined = this.actualArray as E[];
 		const expectedAsSet = new Set(expected);
-		const actualAsSet = new Set(actualAsNotVoid);
+		const actualAsSet = new Set(actualAsDefined);
 		const missing = new Set([...expectedAsSet].filter(x => !actualAsSet.has(x)));
 		const unwanted = new Set([...actualAsSet].filter(x => !expectedAsSet.has(x)));
 		if (missing.size !== 0 || unwanted.size !== 0)
@@ -197,7 +195,7 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 		return this;
 	}
 
-	containsAny(expected: unknown[], name?: string): ArrayValidator
+	containsAny(expected: E[], name?: string): ArrayValidator<E>
 	{
 		if (typeof (name) !== "undefined")
 			Objects.requireThatStringIsNotEmpty(name, "name");
@@ -206,8 +204,8 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 
 		Objects.requireThatTypeOf(expected, "expected", "array");
 
-		const actualAsNotVoid = this.actualArray as unknown[];
-		if (!ArrayValidatorImpl.arrayContainsAny(actualAsNotVoid, expected))
+		const actualAsDefined = this.actualArray as E[];
+		if (!this.arrayContainsAny(actualAsDefined, expected))
 		{
 			let failure;
 			if (name)
@@ -228,7 +226,7 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 		return this;
 	}
 
-	containsAll(expected: unknown[], name?: string): ArrayValidator
+	containsAll(expected: E[], name?: string): ArrayValidator<E>
 	{
 		if (typeof (name) !== "undefined")
 			Objects.requireThatStringIsNotEmpty(name, "name");
@@ -237,11 +235,11 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 
 		Objects.requireThatTypeOf(expected, "expected", "array");
 
-		const actualAsNotVoid = this.actualArray as unknown[];
-		if (!ArrayValidatorImpl.arrayContainsAll(actualAsNotVoid, expected))
+		const actualAsDefined = this.actualArray as E[];
+		if (!this.arrayContainsAll(actualAsDefined, expected))
 		{
 			const expectedAsSet = new Set(expected);
-			const actualAsSet = new Set(actualAsNotVoid);
+			const actualAsSet = new Set(actualAsDefined);
 			const missing = new Set([...expectedAsSet].filter(x => !actualAsSet.has(x)));
 			let failure;
 			if (name)
@@ -264,16 +262,15 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 		return this;
 	}
 
-	doesNotContain(element: unknown, name?: string): ArrayValidator
+	doesNotContain(element: E, name?: string): ArrayValidator<E>
 	{
 		if (typeof (name) !== "undefined")
 			Objects.requireThatStringIsNotEmpty(name, "name");
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			return this;
 
-
-		const actualAsNotVoid = this.actualArray as unknown[];
-		if (ArrayValidatorImpl.arrayContainsElement(actualAsNotVoid, element))
+		const actualAsDefined = this.actualArray as E[];
+		if (this.arrayContainsElement(actualAsDefined, element))
 		{
 			let failure;
 			if (name)
@@ -294,7 +291,7 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 		return this;
 	}
 
-	doesNotContainAny(elements: unknown[], name?: string): ArrayValidator
+	doesNotContainAny(elements: E[], name?: string): ArrayValidator<E>
 	{
 		if (typeof (name) !== "undefined")
 			Objects.requireThatStringIsNotEmpty(name, "name");
@@ -303,8 +300,8 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 
 		Objects.requireThatTypeOf(elements, "elements", "array");
 
-		const actualAsNotVoid = this.actualArray as unknown[];
-		if (ArrayValidatorImpl.arrayContainsAny(actualAsNotVoid, elements))
+		const actualAsDefined = this.actualArray as E[];
+		if (this.arrayContainsAny(actualAsDefined, elements))
 		{
 			let failure;
 			if (name)
@@ -325,7 +322,7 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 		return this;
 	}
 
-	doesNotContainAll(elements: unknown[], name?: string): ArrayValidator
+	doesNotContainAll(elements: E[], name?: string): ArrayValidator<E>
 	{
 		if (typeof (name) !== "undefined")
 			Objects.requireThatStringIsNotEmpty(name, "name");
@@ -334,11 +331,11 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 
 		Objects.requireThatTypeOf(elements, "elements", "array");
 
-		const actualAsNotVoid = this.actualArray as unknown[];
-		if (ArrayValidatorImpl.arrayContainsAll(actualAsNotVoid, elements))
+		const actualAsDefined = this.actualArray as E[];
+		if (this.arrayContainsAll(actualAsDefined, elements))
 		{
 			const elementsAsSet = new Set(elements);
-			const actualAsSet = new Set(actualAsNotVoid);
+			const actualAsSet = new Set(actualAsDefined);
 			const missing = new Set([...elementsAsSet].filter(x => !actualAsSet.has(x)));
 			let failure;
 			if (name)
@@ -361,16 +358,15 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 		return this;
 	}
 
-	doesNotContainDuplicates(): ArrayValidator
+	doesNotContainDuplicates(): ArrayValidator<E>
 	{
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			return this;
 
-
 		const unique = new Set();
 		const duplicates = new Set();
-		const actualAsNotVoid = this.actualArray as unknown[];
-		for (const element of actualAsNotVoid)
+		const actualAsDefined = this.actualArray as E[];
+		for (const element of actualAsDefined)
 		{
 			if (unique.has(element))
 				duplicates.add(element);
@@ -390,7 +386,7 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 
 	length(): NumberValidator
 	{
-		let value: void | unknown[];
+		let value: E[] | undefined;
 		let length;
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 		{
@@ -399,14 +395,14 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 		}
 		else
 		{
-			value = this.actualArray as unknown[];
+			value = this.actualArray as E[];
 			length = value.length;
 		}
 		return new SizeValidatorImpl(this.config, value, this.name, length, this.name + ".length",
 			this.pluralizer, this.failures);
 	}
 
-	lengthConsumer(consumer: (length: NumberValidator) => void): ArrayValidator
+	lengthConsumer(consumer: (length: NumberValidator) => void): ArrayValidator<E>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		if (this.failures.length === 0)
@@ -414,20 +410,42 @@ class ArrayValidatorImpl extends AbstractObjectValidator<ArrayValidator>
 		return this;
 	}
 
-	asSet(): SetValidator
+	asArray<E>(): ArrayValidator<E>;
+	asArray(): ArrayValidator<E>
 	{
-		let value: void | Set<unknown>;
+		return this;
+	}
+
+	asArrayConsumer<E2>(consumer: (input: ArrayValidator<E2>) => void): ArrayValidator<E>
+	asArrayConsumer(consumer: (input: ArrayValidator<E>) => void): ArrayValidator<E>
+	{
+		return super.asArrayConsumer(consumer);
+	}
+
+	asSet<E>(): SetValidator<E>;
+	asSet(): SetValidator<E>
+	{
+		let value: Set<E> | undefined;
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			value = undefined;
 		else
 		{
-			const actualAsNotVoid = this.actualArray as unknown[];
-			value = new Set(actualAsNotVoid);
+			const actualAsDefined = this.actualArray as E[];
+			value = new Set(actualAsDefined);
 		}
-		return new SetValidatorImpl(this.config, value, this.name + ".asSet()", this.failures);
+		return new SetValidatorImpl<E>(this.config, value, this.name + ".asSet()", this.failures);
 	}
 
-	getActual(): void | unknown[]
+	asSetConsumer<S, E>(consumer: (actual: SetValidator<E>) => void): S;
+	asSetConsumer(consumer: (actual: SetValidator<E>) => void): ArrayValidator<E>
+	{
+		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
+		if (this.failures.length === 0)
+			consumer(this.asSet());
+		return this.getThis();
+	}
+
+	getActual(): E[] | undefined
 	{
 		return this.actualArray;
 	}

--- a/src/internal/ArrayVerifierImpl.mts
+++ b/src/internal/ArrayVerifierImpl.mts
@@ -13,9 +13,11 @@ import {
 
 /**
  * Default implementation of <code>ArrayVerifier</code>.
+ *
+ * @typeParam E - the type the array elements
  */
-class ArrayVerifierImpl extends AbstractObjectVerifier<ArrayVerifier, ArrayValidator>
-	implements ArrayVerifier
+class ArrayVerifierImpl<E> extends AbstractObjectVerifier<ArrayVerifier<E>, ArrayValidator<E>, E[]>
+	implements ArrayVerifier<E>
 {
 	/**
 	 * Creates a new ArrayVerifierImpl.
@@ -23,7 +25,7 @@ class ArrayVerifierImpl extends AbstractObjectVerifier<ArrayVerifier, ArrayValid
 	 * @param validator - the validator to delegate to
 	 * @throws TypeError if <code>validator</code> is null or undefined
 	 */
-	constructor(validator: ArrayValidator)
+	constructor(validator: ArrayValidator<E>)
 	{
 		super(validator);
 	}
@@ -45,49 +47,49 @@ class ArrayVerifierImpl extends AbstractObjectVerifier<ArrayVerifier, ArrayValid
 		return this.validationResult(() => this.getThis());
 	}
 
-	contains(element: unknown, name?: string)
+	contains(element: E, name?: string)
 	{
 		this.validator.contains(element, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	containsExactly(expected: unknown[], name?: string)
+	containsExactly(expected: E[], name?: string)
 	{
 		this.validator.containsExactly(expected, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	containsAny(expected: unknown[], name?: string)
+	containsAny(expected: E[], name?: string)
 	{
 		this.validator.containsAny(expected, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	containsAll(expected: unknown[], name?: string)
+	containsAll(expected: E[], name?: string)
 	{
 		this.validator.containsAll(expected, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	doesNotContain(element: unknown, name?: string)
+	doesNotContain(element: E, name?: string)
 	{
 		this.validator.doesNotContain(element, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	doesNotContainAny(elements: unknown[], name?: string): ArrayVerifier
+	doesNotContainAny(elements: E[], name?: string): ArrayVerifier<E>
 	{
 		this.validator.doesNotContainAny(elements, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	doesNotContainAll(elements: unknown[], name?: string): ArrayVerifier
+	doesNotContainAll(elements: E[], name?: string): ArrayVerifier<E>
 	{
 		this.validator.doesNotContainAll(elements, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	doesNotContainDuplicates(): ArrayVerifier
+	doesNotContainDuplicates(): ArrayVerifier<E>
 	{
 		this.validator.doesNotContainDuplicates();
 		return this.validationResult(() => this.getThis());
@@ -99,29 +101,26 @@ class ArrayVerifierImpl extends AbstractObjectVerifier<ArrayVerifier, ArrayValid
 		return this.validationResult(() => new NumberVerifierImpl(newValidator)) as NumberVerifier;
 	}
 
-	lengthConsumer(consumer: (actual: NumberVerifier) => void): ArrayVerifier
+	lengthConsumer(consumer: (actual: NumberVerifier) => void): ArrayVerifier<E>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.length());
 		return this;
 	}
 
-	asSet(): SetVerifier
+	asSet<E>(): SetVerifier<E>;
+	asSet(): SetVerifier<E>
 	{
 		const newValidator = this.validator.asSet();
-		return this.validationResult(() => new SetVerifierImpl(newValidator)) as SetVerifier;
+		return this.validationResult(() => new SetVerifierImpl(newValidator)) as SetVerifier<E>;
 	}
 
-	asSetConsumer(consumer: (actual: SetVerifier) => void): ArrayVerifier
+	asSetConsumer<S, E>(consumer: (actual: SetVerifier<E>) => void): S;
+	asSetConsumer(consumer: (actual: SetVerifier<E>) => void): ArrayVerifier<E>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.asSet());
 		return this;
-	}
-
-	getActual(): unknown[]
-	{
-		return super.getActual() as unknown[];
 	}
 }
 

--- a/src/internal/BooleanValidatorImpl.mts
+++ b/src/internal/BooleanValidatorImpl.mts
@@ -10,7 +10,7 @@ import {
 /**
  * Default implementation of <code>BooleanValidator</code>.
  */
-class BooleanValidatorImpl extends AbstractObjectValidator<BooleanValidator>
+class BooleanValidatorImpl extends AbstractObjectValidator<BooleanValidator, boolean>
 	implements BooleanValidator
 {
 	private readonly actualBoolean: boolean;
@@ -25,7 +25,7 @@ class BooleanValidatorImpl extends AbstractObjectValidator<BooleanValidator>
 	 * @throws TypeError if <code>configuration</code> or <code>name</code> are null or undefined
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	constructor(configuration: Configuration, actual: unknown, name: string, failures: ValidationFailure[])
+	constructor(configuration: Configuration, actual: boolean | undefined, name: string, failures: ValidationFailure[])
 	{
 		super(configuration, actual, name, failures);
 		this.actualBoolean = actual as boolean;
@@ -40,7 +40,6 @@ class BooleanValidatorImpl extends AbstractObjectValidator<BooleanValidator>
 	{
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			return this;
-
 
 		if (!this.actualBoolean)
 		{
@@ -65,9 +64,9 @@ class BooleanValidatorImpl extends AbstractObjectValidator<BooleanValidator>
 		return this;
 	}
 
-	getActual(): void | boolean
+	getActual(): boolean | undefined
 	{
-		return super.getActual() as void | boolean;
+		return super.getActual() as boolean | undefined;
 	}
 }
 

--- a/src/internal/BooleanVerifierImpl.mts
+++ b/src/internal/BooleanVerifierImpl.mts
@@ -7,7 +7,7 @@ import {AbstractObjectVerifier} from "./internal.mjs";
 /**
  * Default implementation of <code>BooleanVerifier</code>.
  */
-class BooleanVerifierImpl extends AbstractObjectVerifier<BooleanVerifier, BooleanValidator>
+class BooleanVerifierImpl extends AbstractObjectVerifier<BooleanVerifier, BooleanValidator, boolean>
 	implements BooleanVerifier
 {
 	/**

--- a/src/internal/ClassValidatorImpl.mts
+++ b/src/internal/ClassValidatorImpl.mts
@@ -11,7 +11,8 @@ import {
 /**
  * Default implementation of <code>ClassValidator</code>.
  */
-class ClassValidatorImpl extends AbstractObjectValidator<ClassValidator>
+// eslint-disable-next-line @typescript-eslint/ban-types
+class ClassValidatorImpl extends AbstractObjectValidator<ClassValidator, Function>
 	implements ClassValidator
 {
 	protected getThis()
@@ -33,7 +34,8 @@ class ClassValidatorImpl extends AbstractObjectValidator<ClassValidator>
 	 *   <code>isIpV6</code>, <code>isHostname</code> are null or undefined
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	constructor(configuration: Configuration, actual: unknown, name: string, failures: ValidationFailure[])
+	// eslint-disable-next-line @typescript-eslint/ban-types
+	constructor(configuration: Configuration, actual: Function | undefined, name: string, failures: ValidationFailure[])
 	{
 		super(configuration, actual, name, failures);
 
@@ -46,7 +48,6 @@ class ClassValidatorImpl extends AbstractObjectValidator<ClassValidator>
 	{
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			return this;
-
 
 		const typeInfo = Objects.getTypeInfo(type);
 		let failure;
@@ -107,7 +108,7 @@ class ClassValidatorImpl extends AbstractObjectValidator<ClassValidator>
 	}
 
 	// eslint-disable-next-line @typescript-eslint/ban-types
-	getActual(): void | Function
+	getActual(): Function | undefined
 	{
 		return this.actualClass;
 	}

--- a/src/internal/ClassVerifierImpl.mts
+++ b/src/internal/ClassVerifierImpl.mts
@@ -7,7 +7,8 @@ import {AbstractObjectVerifier} from "./internal.mjs";
 /**
  * Default implementation of <code>ClassVerifier</code>.
  */
-class ClassVerifierImpl extends AbstractObjectVerifier<ClassVerifier, ClassValidator>
+// eslint-disable-next-line @typescript-eslint/ban-types
+class ClassVerifierImpl extends AbstractObjectVerifier<ClassVerifier, ClassValidator, Function>
 	implements ClassVerifier
 {
 	/**
@@ -38,13 +39,6 @@ class ClassVerifierImpl extends AbstractObjectVerifier<ClassVerifier, ClassValid
 	{
 		this.validator.isSubtypeOf(type);
 		return this.validationResult(() => this.getThis());
-	}
-
-	// eslint-disable-next-line @typescript-eslint/ban-types
-	getActual()
-	{
-		// eslint-disable-next-line @typescript-eslint/ban-types
-		return super.getActual() as Function;
 	}
 }
 

--- a/src/internal/InetAddressValidatorImpl.mts
+++ b/src/internal/InetAddressValidatorImpl.mts
@@ -11,7 +11,7 @@ import {
 /**
  * Default implementation of <code>InetAddressValidator</code>.
  */
-class InetAddressValidatorImpl extends AbstractObjectValidator<InetAddressValidator>
+class InetAddressValidatorImpl extends AbstractObjectValidator<InetAddressValidator, string>
 	implements InetAddressValidator
 {
 	private readonly addressIsIpV4: boolean;
@@ -32,7 +32,7 @@ class InetAddressValidatorImpl extends AbstractObjectValidator<InetAddressValida
 	 *   <code>isIpV6</code>, <code>isHostname</code> are null or undefined
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	constructor(configuration: Configuration, actual: void | string, name: string, isIpV4: boolean, isIpV6: boolean,
+	constructor(configuration: Configuration, actual: string | undefined, name: string, isIpV4: boolean, isIpV6: boolean,
 		isHostname: boolean, failures: ValidationFailure[])
 	{
 		super(configuration, actual, name, failures);
@@ -55,7 +55,6 @@ class InetAddressValidatorImpl extends AbstractObjectValidator<InetAddressValida
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			return this;
 
-
 		if (!this.addressIsIpV4)
 		{
 			const failure = new ValidationFailure(this.config, RangeError,
@@ -70,7 +69,6 @@ class InetAddressValidatorImpl extends AbstractObjectValidator<InetAddressValida
 	{
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			return this;
-
 
 		if (!this.addressIsIpV6)
 		{

--- a/src/internal/InetAddressVerifierImpl.mts
+++ b/src/internal/InetAddressVerifierImpl.mts
@@ -7,7 +7,7 @@ import {AbstractObjectVerifier} from "./internal.mjs";
 /**
  * Default implementation of <code>InetAddressVerifier</code>.
  */
-class InetAddressVerifierImpl extends AbstractObjectVerifier<InetAddressVerifier, InetAddressValidator>
+class InetAddressVerifierImpl extends AbstractObjectVerifier<InetAddressVerifier, InetAddressValidator, string>
 	implements InetAddressVerifier
 {
 	/**
@@ -42,11 +42,6 @@ class InetAddressVerifierImpl extends AbstractObjectVerifier<InetAddressVerifier
 	{
 		this.validator.isHostname();
 		return this.validationResult(() => this.getThis());
-	}
-
-	getActual(): string
-	{
-		return super.getActual() as string;
 	}
 }
 

--- a/src/internal/MapValidatorImpl.mts
+++ b/src/internal/MapValidatorImpl.mts
@@ -15,11 +15,14 @@ import {
 
 /**
  * Default implementation of <code>MapValidator</code>.
+ *
+ * @typeParam K - the type the map's keys
+ * @typeParam V - the type the map's values
  */
-class MapValidatorImpl extends AbstractObjectValidator<MapValidator>
-	implements MapValidator
+class MapValidatorImpl<K, V> extends AbstractObjectValidator<MapValidator<K, V>, Map<K, V>>
+	implements MapValidator<K, V>
 {
-	private readonly actualMap: Map<unknown, unknown>;
+	private readonly actualMap: Map<K, V>;
 
 	/**
 	 * Creates a new MapValidatorImpl.
@@ -31,10 +34,10 @@ class MapValidatorImpl extends AbstractObjectValidator<MapValidator>
 	 * @throws TypeError if <code>configuration</code> or <code>name</code> are null or undefined
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	constructor(configuration: Configuration, actual: unknown, name: string, failures: ValidationFailure[])
+	constructor(configuration: Configuration, actual: Map<K, V> | undefined, name: string, failures: ValidationFailure[])
 	{
 		super(configuration, actual, name, failures);
-		this.actualMap = this.actual as Map<unknown, unknown>;
+		this.actualMap = this.actual as Map<K, V>;
 	}
 
 	protected getThis()
@@ -70,7 +73,7 @@ class MapValidatorImpl extends AbstractObjectValidator<MapValidator>
 
 	keys()
 	{
-		let value: void | unknown[];
+		let value: K[] | undefined;
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			value = undefined;
 		else
@@ -78,7 +81,7 @@ class MapValidatorImpl extends AbstractObjectValidator<MapValidator>
 		return new ArrayValidatorImpl(this.config, value, this.name + ".keys()", Pluralizer.KEY, this.failures);
 	}
 
-	keysConsumer(consumer: (actual: ArrayValidator) => void)
+	keysConsumer(consumer: (actual: ArrayValidator<K>) => void)
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		if (this.failures.length === 0)
@@ -88,7 +91,7 @@ class MapValidatorImpl extends AbstractObjectValidator<MapValidator>
 
 	values()
 	{
-		let value: void | unknown[];
+		let value: V[] | undefined;
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			value = undefined;
 		else
@@ -97,7 +100,7 @@ class MapValidatorImpl extends AbstractObjectValidator<MapValidator>
 			this.failures);
 	}
 
-	valuesConsumer(consumer: (actual: ArrayValidator) => void)
+	valuesConsumer(consumer: (actual: ArrayValidator<V>) => void)
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		if (this.failures.length === 0)
@@ -107,7 +110,7 @@ class MapValidatorImpl extends AbstractObjectValidator<MapValidator>
 
 	entries()
 	{
-		let value: void | unknown[];
+		let value: [K, V][] | undefined;
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			value = undefined;
 		else
@@ -116,7 +119,7 @@ class MapValidatorImpl extends AbstractObjectValidator<MapValidator>
 			this.failures);
 	}
 
-	entriesConsumer(consumer: (actual: ArrayValidator) => void): MapValidator
+	entriesConsumer(consumer: (actual: ArrayValidator<[K, V]>) => void): MapValidator<K, V>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		if (this.failures.length === 0)
@@ -126,7 +129,7 @@ class MapValidatorImpl extends AbstractObjectValidator<MapValidator>
 
 	size(): NumberValidator
 	{
-		let value: void | unknown[] | Set<unknown> | Map<unknown, unknown> | string;
+		let value: unknown;
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			value = undefined;
 		else
@@ -135,7 +138,7 @@ class MapValidatorImpl extends AbstractObjectValidator<MapValidator>
 			Pluralizer.ENTRY, this.failures);
 	}
 
-	sizeConsumer(consumer: (actual: NumberValidator) => void): MapValidator
+	sizeConsumer(consumer: (actual: NumberValidator) => void): MapValidator<K, V>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		if (this.failures.length === 0)
@@ -143,7 +146,20 @@ class MapValidatorImpl extends AbstractObjectValidator<MapValidator>
 		return this;
 	}
 
-	getActual(): Map<unknown, unknown>
+	asMap<K, V>(): MapValidator<K, V>;
+	asMap(): MapValidator<K, V>
+	{
+		return this;
+	}
+
+	asMapConsumer<K2, V2>(consumer: (input: MapValidator<K2, V2>) => void): MapValidator<K, V>;
+	asMapConsumer(consumer: (input: MapValidator<K, V>) => void): MapValidator<K, V>
+	{
+		return super.asMapConsumer(consumer);
+	}
+
+
+	getActual(): Map<K, V>
 	{
 		return this.actualMap;
 	}

--- a/src/internal/MapVerifierImpl.mts
+++ b/src/internal/MapVerifierImpl.mts
@@ -13,9 +13,12 @@ import {
 
 /**
  * Default implementation of <code>MapVerifier</code>.
+ *
+ * @typeParam K - the type the map's keys
+ * @typeParam V - the type the map's values
  */
-class MapVerifierImpl extends AbstractObjectVerifier<MapVerifier, MapValidator>
-	implements MapVerifier
+class MapVerifierImpl<K, V> extends AbstractObjectVerifier<MapVerifier<K, V>, MapValidator<K, V>, Map<K, V>>
+	implements MapVerifier<K, V>
 {
 	/**
 	 * Creates a new MapVerifierImpl.
@@ -23,7 +26,7 @@ class MapVerifierImpl extends AbstractObjectVerifier<MapVerifier, MapValidator>
 	 * @param validator - the validator to delegate to
 	 * @throws TypeError if <code>validator</code> is null or undefined
 	 */
-	constructor(validator: MapValidator)
+	constructor(validator: MapValidator<K, V>)
 	{
 		super(validator);
 	}
@@ -48,10 +51,10 @@ class MapVerifierImpl extends AbstractObjectVerifier<MapVerifier, MapValidator>
 	keys()
 	{
 		const newValidator = this.validator.keys();
-		return this.validationResult(() => new ArrayVerifierImpl(newValidator)) as ArrayVerifier;
+		return this.validationResult(() => new ArrayVerifierImpl(newValidator)) as ArrayVerifier<K>;
 	}
 
-	keysConsumer(consumer: (actual: ArrayVerifier) => void)
+	keysConsumer(consumer: (actual: ArrayVerifier<K>) => void)
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.keys());
@@ -61,10 +64,10 @@ class MapVerifierImpl extends AbstractObjectVerifier<MapVerifier, MapValidator>
 	values()
 	{
 		const newValidator = this.validator.values();
-		return this.validationResult(() => new ArrayVerifierImpl(newValidator)) as ArrayVerifier;
+		return this.validationResult(() => new ArrayVerifierImpl(newValidator)) as ArrayVerifier<V>;
 	}
 
-	valuesConsumer(consumer: (actual: ArrayVerifier) => void)
+	valuesConsumer(consumer: (actual: ArrayVerifier<V>) => void)
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.values());
@@ -74,10 +77,10 @@ class MapVerifierImpl extends AbstractObjectVerifier<MapVerifier, MapValidator>
 	entries()
 	{
 		const newValidator = this.validator.entries();
-		return this.validationResult(() => new ArrayVerifierImpl(newValidator)) as ArrayVerifier;
+		return this.validationResult(() => new ArrayVerifierImpl(newValidator)) as ArrayVerifier<[K, V]>;
 	}
 
-	entriesConsumer(consumer: (actual: ArrayVerifier) => void)
+	entriesConsumer(consumer: (actual: ArrayVerifier<[K, V]>) => void)
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.entries());
@@ -90,16 +93,11 @@ class MapVerifierImpl extends AbstractObjectVerifier<MapVerifier, MapValidator>
 		return this.validationResult(() => new NumberVerifierImpl(newValidator)) as NumberVerifier;
 	}
 
-	sizeConsumer(consumer: (actual: NumberVerifier) => void): MapVerifier
+	sizeConsumer(consumer: (actual: NumberVerifier) => void): MapVerifier<K, V>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.size());
 		return this;
-	}
-
-	getActual(): Map<unknown, unknown>
-	{
-		return super.getActual() as Map<unknown, unknown>;
 	}
 }
 

--- a/src/internal/NumberValidatorImpl.mts
+++ b/src/internal/NumberValidatorImpl.mts
@@ -21,7 +21,7 @@ class NumberValidatorImpl extends AbstractNumberValidator<NumberValidator>
 	 * @throws TypeError if <code>configuration</code> or <code>name</code> are null or undefined
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	constructor(configuration: Configuration, actual: unknown, name: string, failures: ValidationFailure[])
+	constructor(configuration: Configuration, actual: number | undefined, name: string, failures: ValidationFailure[])
 	{
 		super(configuration, actual, name, failures);
 	}

--- a/src/internal/ObjectValidatorImpl.mts
+++ b/src/internal/ObjectValidatorImpl.mts
@@ -7,9 +7,11 @@ import {AbstractObjectValidator} from "./internal.mjs";
 
 /**
  * Default implementation of <code>ObjectValidator</code>.
+ *
+ * @typeParam T - the type the actual value
  */
-class ObjectValidatorImpl extends AbstractObjectValidator<ObjectValidator>
-	implements ObjectValidator
+class ObjectValidatorImpl<T> extends AbstractObjectValidator<ObjectValidator<T>, T>
+	implements ObjectValidator<T>
 {
 	/**
 	 * Creates a new ObjectValidator.
@@ -21,13 +23,13 @@ class ObjectValidatorImpl extends AbstractObjectValidator<ObjectValidator>
 	 * @throws TypeError if <code>configuration</code> or <code>name</code> are null or undefined
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	constructor(configuration: Configuration, actual: unknown, name: string,
+	constructor(configuration: Configuration, actual: T, name: string,
 		failures: ValidationFailure[])
 	{
 		super(configuration, actual, name, failures);
 	}
 
-	protected getThis(): ObjectValidator
+	protected getThis(): ObjectValidator<T>
 	{
 		return this;
 	}

--- a/src/internal/ObjectVerifierImpl.mts
+++ b/src/internal/ObjectVerifierImpl.mts
@@ -1,31 +1,33 @@
 import type {
-	ArrayVerifier,
-	BooleanVerifier,
-	ClassVerifier,
-	InetAddressVerifier,
-	MapVerifier,
-	NumberVerifier,
 	ObjectValidator,
 	ObjectVerifier,
+	StringVerifier,
+	ArrayVerifier,
+	BooleanVerifier,
+	NumberVerifier,
 	SetVerifier,
-	StringVerifier
+	MapVerifier,
+	InetAddressVerifier,
+	ClassVerifier
 } from "./internal.mjs";
 import {
+	Objects,
+	StringVerifierImpl,
 	ArrayVerifierImpl,
 	BooleanVerifierImpl,
-	ClassVerifierImpl,
-	InetAddressVerifierImpl,
-	MapVerifierImpl,
 	NumberVerifierImpl,
-	Objects,
 	SetVerifierImpl,
-	StringVerifierImpl
+	MapVerifierImpl,
+	InetAddressVerifierImpl,
+	ClassVerifierImpl
 } from "./internal.mjs";
 
 /**
  * Default implementation of <code>ObjectVerifier</code>.
+ *
+ * @typeParam T - the type the actual value
  */
-class ObjectVerifierImpl<V extends ObjectValidator> implements ObjectVerifier
+class ObjectVerifierImpl<V extends ObjectValidator<T>, T> implements ObjectVerifier<T>
 {
 	protected readonly validator: V;
 
@@ -46,17 +48,7 @@ class ObjectVerifierImpl<V extends ObjectValidator> implements ObjectVerifier
 		return this;
 	}
 
-	/**
-	 * Ensures that the actual value is equal to a value.
-	 *
-	 * @param expected - the expected value
-	 * @param name - (optional) the name of the expected value
-	 * @returns the updated verifier
-	 * @throws TypeError  if <code>name</code> is null
-	 * @throws RangeError if <code>name</code> is empty.
-	 * If the actual value is not equal to <code>expected</code>.
-	 */
-	isEqualTo(expected: unknown, name?: string)
+	isEqualTo(expected: T, name?: string)
 	{
 		this.validator.isEqualTo(expected, name);
 		return this.validationResult(() => this.getThis());
@@ -84,327 +76,171 @@ class ObjectVerifierImpl<V extends ObjectValidator> implements ObjectVerifier
 		throw failure.createException();
 	}
 
-	/**
-	 * Ensures that the actual value is not equal to a value.
-	 *
-	 * @param value - the value to compare to
-	 * @param name - (optional) the name of the expected value
-	 * @returns the updated verifier
-	 * @throws TypeError  if <code>name</code> is null
-	 * @throws RangeError if <code>name</code> is empty.
-	 * If the actual value is equal to <code>value</code>.
-	 */
-	isNotEqualTo(value: unknown, name?: string): ObjectVerifier
+	isNotEqualTo(value: T, name?: string): ObjectVerifier<T>
 	{
 		this.validator.isNotEqualTo(value, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	/**
-	 * Ensures that the actual value is a primitive. To check if the actual value is an object, use
-	 * <code>isInstanceOf(Object)</code>.
-	 *
-	 * @returns the updated verifier
-	 * @throws RangeError if the actual value is not a <code>string</code>, <code>number</code>,
-	 *   <code>bigint</code>, <code>boolean</code>, <code>null</code>, <code>undefined</code>, or
-	 *   <code>symbol</code>
-	 */
-	isPrimitive(): ObjectVerifier
+	isPrimitive(): ObjectVerifier<T>
 	{
 		this.validator.isPrimitive();
 		return this.validationResult(() => this.getThis());
 	}
 
-	/**
-	 * Ensures that <code>typeof(actual)</code> is equal to <code>type</code>.
-	 *
-	 * @param type - the expected
-	 * <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof">typeof</a>
-	 * of the actual value
-	 * @returns the updated verifier
-	 * @throws RangeError if the <code>typeof(actual)</code> is not equal to <code>type</code>
-	 */
-	isTypeOf(type: string): ObjectVerifier
+	isTypeOf(type: string): ObjectVerifier<T>
 	{
 		this.validator.isTypeOf(type);
 		return this.validationResult(() => this.getThis());
 	}
 
-	/**
-	 * Ensures that the actual value is an object that is an instance of the specified type.
-	 *
-	 * @param type - the type to compare to
-	 * @returns the updated verifier
-	 * @throws TypeError  if <code>type</code> is undefined, null, anonymous function or an arrow function
-	 * @throws RangeError if the actual value is not an instance of <code>type</code>
-	 */
 	// eslint-disable-next-line @typescript-eslint/ban-types
-	isInstanceOf(type: Function): ObjectVerifier
+	isInstanceOf(type: Function): ObjectVerifier<T>
 	{
 		this.validator.isInstanceOf(type);
 		return this.validationResult(() => this.getThis());
 	}
 
-	/**
-	 * Ensures that the actual value is null.
-	 *
-	 * @returns the updated verifier
-	 * @throws RangeError if the actual value is not null
-	 */
-	isNull(): ObjectVerifier
+	isNull(): ObjectVerifier<T>
 	{
 		this.validator.isNull();
 		return this.validationResult(() => this.getThis());
 	}
 
-	/**
-	 * Ensures that the actual value is not null.
-	 *
-	 * @returns the updated verifier
-	 * @throws RangeError if the actual value is null
-	 */
-	isNotNull(): ObjectVerifier
+	isNotNull(): ObjectVerifier<T>
 	{
 		this.validator.isNotNull();
 		return this.validationResult(() => this.getThis());
 	}
 
-	/**
-	 * Ensures that the actual value is defined.
-	 *
-	 * @returns the updated verifier
-	 * @throws RangeError if the actual value is undefined
-	 */
-	isDefined(): ObjectVerifier
+	isDefined(): ObjectVerifier<T>
 	{
 		this.validator.isDefined();
 		return this.validationResult(() => this.getThis());
 	}
 
-	/**
-	 * Ensures that the actual value is undefined.
-	 *
-	 * @returns the updated verifier
-	 * @throws RangeError if the actual value is not undefined
-	 */
-	isNotDefined(): ObjectVerifier
+	isNotDefined(): ObjectVerifier<T>
 	{
 		this.validator.isNotDefined();
 		return this.validationResult(() => this.getThis());
 	}
 
-	/**
-	 * Ensures that value is not undefined or null.
-	 *
-	 * @returns the updated verifier
-	 * @throws TypeError if the value is undefined or null
-	 */
-	isSet(): ObjectVerifier
+	isSet(): ObjectVerifier<T>
 	{
 		this.validator.isSet();
 		return this.validationResult(() => this.getThis());
 	}
 
-	/**
-	 * Ensures that value is not undefined or null.
-	 *
-	 * @returns the updated verifier
-	 * @throws TypeError if the value is not undefined or null
-	 */
-	isNotSet(): ObjectVerifier
+	isNotSet(): ObjectVerifier<T>
 	{
 		this.validator.isNotSet();
 		return this.validationResult(() => this.getThis());
 	}
 
-	/**
-	 * Returns the actual value.
-	 *
-	 * @returns the actual value
-	 */
-	getActual(): unknown
+	getActual(): T
 	{
-		return this.validator.getActual();
+		// The verifier is guaranteed to throw an exception if validation fails
+		return this.validator.getActual() as T;
 	}
 
-	/**
-	 * @returns a verifier for the object's string representation
-	 */
 	asString(): StringVerifier
 	{
 		const newValidator = this.validator.asString();
 		return this.validationResult(() => new StringVerifierImpl(newValidator)) as StringVerifier;
 	}
 
-	/**
-	 * @param consumer - a function that accepts a {@link StringVerifier} for the string representation of the
-	 * actual value
-	 * @returns the updated verifier
-	 * @throws TypeError if <code>consumer</code> is not set
-	 */
-	asStringConsumer(consumer: (actual: StringVerifier) => void): ObjectVerifier
+	asStringConsumer(consumer: (actual: StringVerifier) => void): ObjectVerifier<T>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.asString());
 		return this;
 	}
 
-	/**
-	 * @returns a verifier for the <code>Array</code>
-	 * @throws TypeError if the actual value is not an <code>Array</code>
-	 */
-	asArray(): ArrayVerifier
+	asArray<E>(): ArrayVerifier<E>
 	{
 		const newValidator = this.validator.asArray();
-		return this.validationResult(() => new ArrayVerifierImpl(newValidator)) as ArrayVerifier;
+		return this.validationResult(() => new ArrayVerifierImpl(newValidator)) as ArrayVerifier<E>;
 	}
 
-	/**
-	 * @param consumer - a function that accepts a {@link ArrayVerifier} for the actual value
-	 * @returns the updated verifier
-	 * @throws TypeError if <code>consumer</code> is not set.
-	 * If the actual value is not an <code>Array</code>.
-	 */
-	asArrayConsumer(consumer: (actual: ArrayVerifier) => void): ObjectVerifier
+	asArrayConsumer<E>(consumer: (actual: ArrayVerifier<E>) => void): ObjectVerifier<T>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.asArray());
 		return this;
 	}
 
-	/**
-	 * @returns a verifier for the <code>boolean</code>
-	 * @throws TypeError if the actual value is not a <code>boolean</code>
-	 */
 	asBoolean(): BooleanVerifier
 	{
 		const newValidator = this.validator.asBoolean();
 		return this.validationResult(() => new BooleanVerifierImpl(newValidator)) as BooleanVerifier;
 	}
 
-	/**
-	 * @param consumer - a function that accepts a {@link BooleanVerifier} for the actual value
-	 * @returns the updated verifier
-	 * @throws TypeError if <code>consumer</code> is not set.
-	 * If the actual value is not a <code>boolean</code>.
-	 */
-	asBooleanConsumer(consumer: (actual: BooleanVerifier) => void): ObjectVerifier
+	asBooleanConsumer(consumer: (actual: BooleanVerifier) => void): ObjectVerifier<T>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.asBoolean());
 		return this;
 	}
 
-	/**
-	 * @returns a verifier for the <code>number</code>
-	 * @throws TypeError if the actual value is not a <code>number</code>
-	 */
 	asNumber(): NumberVerifier
 	{
 		const newValidator = this.validator.asNumber();
 		return this.validationResult(() => new NumberVerifierImpl(newValidator)) as NumberVerifier;
 	}
 
-	/**
-	 * @param consumer - a function that accepts a {@link NumberVerifier} for the actual value
-	 * @returns the updated verifier
-	 * @throws TypeError if <code>consumer</code> is not set.
-	 * If the actual value is not a <code>number</code>.
-	 */
-	asNumberConsumer(consumer: (actual: NumberVerifier) => void): ObjectVerifier
+	asNumberConsumer(consumer: (actual: NumberVerifier) => void): ObjectVerifier<T>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.asNumber());
 		return this;
 	}
 
-	/**
-	 * @returns a verifier for the <code>Set</code>
-	 * @throws TypeError if the actual value is not a <code>Set</code>
-	 */
-	asSet(): SetVerifier
+	asSet<E>(): SetVerifier<E>
 	{
 		const newValidator = this.validator.asSet();
-		return this.validationResult(() => new SetVerifierImpl(newValidator)) as SetVerifier;
+		return this.validationResult(() => new SetVerifierImpl(newValidator)) as SetVerifier<E>;
 	}
 
-	/**
-	 * @param consumer - a function that accepts a {@link SetVerifier} for the actual value
-	 * @returns the updated verifier
-	 * @throws TypeError if <code>consumer</code> is not set.
-	 * If the actual value is not a <code>Set</code>.
-	 */
-	asSetConsumer(consumer: (actual: SetVerifier) => void): ObjectVerifier
+	asSetConsumer<E>(consumer: (actual: SetVerifier<E>) => void): ObjectVerifier<T>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.asSet());
 		return this;
 	}
 
-	/**
-	 * @returns a verifier for the <code>Map</code>
-	 * @throws TypeError if the actual value is not a <code>Map</code>
-	 */
-	asMap(): MapVerifier
+	asMap<K, V>(): MapVerifier<K, V>
 	{
 		const newValidator = this.validator.asMap();
-		return this.validationResult(() => new MapVerifierImpl(newValidator)) as MapVerifier;
+		return this.validationResult(() => new MapVerifierImpl(newValidator)) as MapVerifier<K, V>;
 	}
 
-	/**
-	 * @param consumer - a function that accepts a {@link MapVerifier} for the actual value
-	 * @returns the updated verifier
-	 * @throws TypeError if <code>consumer</code> is not set.
-	 * If the actual value is not a <code>Map</code>.
-	 */
-	asMapConsumer(consumer: (actual: MapVerifier) => void): ObjectVerifier
+	asMapConsumer<K, V>(consumer: (actual: MapVerifier<K, V>) => void): ObjectVerifier<T>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.asMap());
 		return this;
 	}
 
-	/**
-	 * @returns a verifier for the value's Internet address representation
-	 * @throws RangeError if the actual value does not contain a valid Internet address format
-	 */
 	asInetAddress(): InetAddressVerifier
 	{
 		const newValidator = this.validator.asInetAddress();
 		return this.validationResult(() => new InetAddressVerifierImpl(newValidator)) as InetAddressVerifier;
 	}
 
-	/**
-	 * @param consumer - a function that accepts an {@link InetAddressVerifier} for the value's Internet
-	 * address representation
-	 * @returns the updated verifier
-	 * @throws TypeError if <code>consumer</code> is not set
-	 * @throws RangeError if the actual value does not contain a valid Internet address format
-	 */
-	asInetAddressConsumer(consumer: (input: InetAddressVerifier) => void): ObjectVerifier
+	asInetAddressConsumer(consumer: (input: InetAddressVerifier) => void): ObjectVerifier<T>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.asInetAddress());
 		return this;
 	}
 
-	/**
-	 * @returns a verifier for the object's class representation
-	 * @throws TypeError if the actual value is not a <code>Function</code>
-	 */
 	asClass(): ClassVerifier
 	{
 		const newValidator = this.validator.asClass();
 		return this.validationResult(() => new ClassVerifierImpl(newValidator)) as ClassVerifier;
 	}
 
-	/**
-	 * @param consumer - a function that accepts a {@link ClassVerifier} for the class representation of the
-	 * actual value
-	 * @returns the updated verifier
-	 * @throws TypeError if <code>consumer</code> is not set
-	 */
-	asClassConsumer(consumer: (actual: ClassVerifier) => void): ObjectVerifier
+	asClassConsumer(consumer: (actual: ClassVerifier) => void): ObjectVerifier<T>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.asClass());

--- a/src/internal/SetVerifierImpl.mts
+++ b/src/internal/SetVerifierImpl.mts
@@ -13,9 +13,11 @@ import {
 
 /**
  * Default implementation of <code>SetVerifier</code>.
+ *
+ * @typeParam E - the type the array elements
  */
-class SetVerifierImpl extends AbstractObjectVerifier<SetVerifier, SetValidator>
-	implements SetVerifier
+class SetVerifierImpl<E> extends AbstractObjectVerifier<SetVerifier<E>, SetValidator<E>, Set<E>>
+	implements SetVerifier<E>
 {
 	/**
 	 * Creates a new SetVerifierImpl.
@@ -23,7 +25,7 @@ class SetVerifierImpl extends AbstractObjectVerifier<SetVerifier, SetValidator>
 	 * @param validator - the validator to delegate to
 	 * @throws TypeError if <code>validator</code> is null or undefined
 	 */
-	constructor(validator: SetValidator)
+	constructor(validator: SetValidator<E>)
 	{
 		super(validator);
 	}
@@ -45,43 +47,43 @@ class SetVerifierImpl extends AbstractObjectVerifier<SetVerifier, SetValidator>
 		return this.validationResult(() => this.getThis());
 	}
 
-	contains(expected: unknown, name?: string)
+	contains(expected: E, name?: string)
 	{
 		this.validator.contains(expected, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	containsExactly(expected: unknown[] | Set<unknown>, name?: string)
+	containsExactly(expected: E[] | Set<E>, name?: string)
 	{
 		this.validator.containsExactly(expected, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	containsAny(expected: unknown[] | Set<unknown>, name?: string)
+	containsAny(expected: E[] | Set<E>, name?: string)
 	{
 		this.validator.containsAny(expected, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	containsAll(expected: unknown[] | Set<unknown>, name?: string)
+	containsAll(expected: E[] | Set<E>, name?: string)
 	{
 		this.validator.containsAll(expected, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	doesNotContain(entry: unknown, name?: string)
+	doesNotContain(entry: E, name?: string)
 	{
 		this.validator.doesNotContain(entry, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	doesNotContainAny(elements: unknown[] | Set<unknown>, name?: string): SetVerifier
+	doesNotContainAny(elements: E[] | Set<E>, name?: string): SetVerifier<E>
 	{
 		this.validator.doesNotContainAny(elements, name);
 		return this.validationResult(() => this.getThis());
 	}
 
-	doesNotContainAll(elements: unknown[] | Set<unknown>, name?: string): SetVerifier
+	doesNotContainAll(elements: E[] | Set<E>, name?: string): SetVerifier<E>
 	{
 		this.validator.doesNotContainAll(elements, name);
 		return this.validationResult(() => this.getThis());
@@ -93,29 +95,32 @@ class SetVerifierImpl extends AbstractObjectVerifier<SetVerifier, SetValidator>
 		return this.validationResult(() => new NumberVerifierImpl(newValidator)) as NumberVerifier;
 	}
 
-	sizeConsumer(consumer: (actual: NumberVerifier) => void): SetVerifier
+	sizeConsumer(consumer: (actual: NumberVerifier) => void): SetVerifier<E>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.size());
 		return this;
 	}
 
-	asArray(): ArrayVerifier
+	asArray<E>(): ArrayVerifier<E>;
+	asArray(): ArrayVerifier<E>
 	{
 		const newValidator = this.validator.asArray();
-		return this.validationResult(() => new ArrayVerifierImpl(newValidator)) as ArrayVerifier;
+		return this.validationResult(() => new ArrayVerifierImpl(newValidator)) as ArrayVerifier<E>;
 	}
 
-	asArrayConsumer(consumer: (actual: ArrayVerifier) => void): SetVerifier
+	asArrayConsumer<E2>(consumer: (actual: ArrayVerifier<E2>) => void): SetVerifier<E>;
+	asArrayConsumer(consumer: (actual: ArrayVerifier<E>) => void): SetVerifier<E>
 	{
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this.asArray());
 		return this;
 	}
 
-	getActual(): Set<unknown>
+	asSet<E>(): SetVerifier<E>;
+	asSet(): SetVerifier<E>
 	{
-		return super.getActual() as Set<unknown>;
+		return this;
 	}
 }
 

--- a/src/internal/SizeValidatorImpl.mts
+++ b/src/internal/SizeValidatorImpl.mts
@@ -15,9 +15,9 @@ import {
 class SizeValidatorImpl extends NumberValidatorImpl
 	implements NumberValidator
 {
-	private readonly collection: void | unknown[] | Set<unknown> | Map<unknown, unknown> | string;
+	private readonly collection: unknown;
 	private readonly collectionName: string;
-	private readonly size: void | number;
+	private readonly size: number | undefined;
 	private readonly pluralizer: Pluralizer;
 
 	/**
@@ -34,9 +34,8 @@ class SizeValidatorImpl extends NumberValidatorImpl
 	 *   undefined or null. If <code>containerName</code> or <code>sizeName</code> are not a string.
 	 * @throws RangeError if <code>containerName</code> or <code>sizeName</code> are empty
 	 */
-	constructor(configuration: Configuration,
-		collection: void | unknown[] | Set<unknown> | Map<unknown, unknown> | string,
-		collectionName: string, size: void | number, sizeName: string, pluralizer: Pluralizer,
+	constructor(configuration: Configuration, collection: unknown,
+		collectionName: string, size: number | undefined, sizeName: string, pluralizer: Pluralizer,
 		failures: ValidationFailure[])
 	{
 		super(configuration, size, sizeName, failures);
@@ -93,8 +92,8 @@ class SizeValidatorImpl extends NumberValidatorImpl
 			}
 			failure.addContext("Actual", this.actual);
 
-			const sizeAsNotVoid = this.size as number;
-			if (sizeAsNotVoid > 0)
+			const sizeAsDefined = this.size as number;
+			if (sizeAsDefined > 0)
 				failure.addContext(this.collectionName, this.collection);
 			this.failures.push(failure);
 		}
@@ -145,15 +144,15 @@ class SizeValidatorImpl extends NumberValidatorImpl
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			return this;
 
-		const sizeAsNotVoid = this.size as number;
-		if (sizeAsNotVoid < startInclusive || sizeAsNotVoid >= endExclusive)
+		const sizeAsDefined = this.size as number;
+		if (sizeAsDefined < startInclusive || sizeAsDefined >= endExclusive)
 		{
 			const failure = new ValidationFailure(this.config, RangeError,
 				this.collectionName + " must contain [" + startInclusive + ", " + endExclusive + ") " +
 				this.pluralizer.nameOf(2) + ".").
-				addContext("Actual", sizeAsNotVoid);
+				addContext("Actual", sizeAsDefined);
 
-			if (sizeAsNotVoid > 0)
+			if (sizeAsDefined > 0)
 				failure.addContext(this.collectionName, this.collection);
 			this.failures.push(failure);
 		}
@@ -173,22 +172,22 @@ class SizeValidatorImpl extends NumberValidatorImpl
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			return this;
 
-		const sizeAsNotVoid = this.size as number;
-		if (sizeAsNotVoid < startInclusive || sizeAsNotVoid > endInclusive)
+		const sizeAsDefined = this.size as number;
+		if (sizeAsDefined < startInclusive || sizeAsDefined > endInclusive)
 		{
 			const failure = new ValidationFailure(this.config, RangeError,
 				this.collectionName + " must contain [" + startInclusive + ", " + endInclusive + "] " +
 				this.pluralizer.nameOf(2) + ".").
-				addContext("Actual", sizeAsNotVoid);
+				addContext("Actual", sizeAsDefined);
 
-			if (sizeAsNotVoid > 0)
+			if (sizeAsDefined > 0)
 				failure.addContext(this.collectionName, this.collection);
 			this.failures.push(failure);
 		}
 		return this;
 	}
 
-	getActual(): void | number
+	getActual(): number | undefined
 	{
 		return this.size;
 	}

--- a/src/internal/StringValidatorImpl.mts
+++ b/src/internal/StringValidatorImpl.mts
@@ -14,7 +14,7 @@ import {
 /**
  * Default implementation of <code>StringValidator</code>.
  */
-class StringValidatorImpl extends AbstractObjectValidator<StringValidator>
+class StringValidatorImpl extends AbstractObjectValidator<StringValidator, string>
 	implements StringValidator
 {
 	private actualString: string;
@@ -29,7 +29,7 @@ class StringValidatorImpl extends AbstractObjectValidator<StringValidator>
 	 * @throws TypeError if <code>configuration</code> or <code>name</code> are null or undefined
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	constructor(configuration: Configuration, actual: unknown, name: string, failures: ValidationFailure[])
+	constructor(configuration: Configuration, actual: string | undefined, name: string, failures: ValidationFailure[])
 	{
 		super(configuration, actual, name, failures);
 		this.actualString = actual as string;
@@ -183,7 +183,7 @@ class StringValidatorImpl extends AbstractObjectValidator<StringValidator>
 
 	length(): NumberValidator
 	{
-		let value: void | number;
+		let value: number | undefined;
 		if (this.failures.length > 0 || !this.requireThatActualIsDefinedAndNotNull())
 			value = undefined;
 		else
@@ -202,12 +202,6 @@ class StringValidatorImpl extends AbstractObjectValidator<StringValidator>
 
 	asString(): StringValidator
 	{
-		if (this.failures.length > 0)
-			return this;
-		if (typeof (this.actualString) === "undefined")
-			return new StringValidatorImpl(this.config, "undefined", this.name, this.failures);
-		if (this.actualString === null)
-			return new StringValidatorImpl(this.config, "null", this.name, this.failures);
 		return this;
 	}
 

--- a/src/internal/StringVerifierImpl.mts
+++ b/src/internal/StringVerifierImpl.mts
@@ -12,7 +12,7 @@ import {
 /**
  * Default implementation of <code>StringVerifier</code>.
  */
-class StringVerifierImpl extends AbstractObjectVerifier<StringVerifier, StringValidator>
+class StringVerifierImpl extends AbstractObjectVerifier<StringVerifier, StringValidator, string>
 	implements StringVerifier
 {
 	/**
@@ -121,11 +121,6 @@ class StringVerifierImpl extends AbstractObjectVerifier<StringVerifier, StringVa
 		Objects.requireThatValueIsDefinedAndNotNull(consumer, "consumer");
 		consumer(this);
 		return this;
-	}
-
-	getActual(): string
-	{
-		return super.getActual() as string;
 	}
 }
 

--- a/src/internal/Strings.mts
+++ b/src/internal/Strings.mts
@@ -18,7 +18,6 @@ class SearchResult
 	}
 }
 
-
 /**
  * String helper functions.
  */

--- a/src/internal/extension/AbstractNumberValidator.mts
+++ b/src/internal/extension/AbstractNumberValidator.mts
@@ -13,7 +13,7 @@ import {
  *
  * @typeParam S - the type of validator returned by the methods
  */
-abstract class AbstractNumberValidator<S> extends AbstractObjectValidator<S>
+abstract class AbstractNumberValidator<S> extends AbstractObjectValidator<S, number>
 	implements ExtensibleNumberValidator<S>
 {
 	private readonly actualNumber: number;
@@ -28,7 +28,7 @@ abstract class AbstractNumberValidator<S> extends AbstractObjectValidator<S>
 	 * @throws TypeError if <code>configuration</code> or <code>name</code> are null or undefined
 	 * @throws RangeError if <code>name</code> is empty
 	 */
-	protected constructor(configuration: Configuration, actual: unknown, name: string,
+	protected constructor(configuration: Configuration, actual: number | undefined, name: string,
 		failures: ValidationFailure[])
 	{
 		super(configuration, actual, name, failures);
@@ -341,9 +341,9 @@ abstract class AbstractNumberValidator<S> extends AbstractObjectValidator<S>
 		return this.getThis();
 	}
 
-	getActual(): void | number
+	getActual(): number | undefined
 	{
-		return super.getActual() as void | number;
+		return super.getActual();
 	}
 }
 

--- a/src/internal/extension/AbstractNumberVerifier.mts
+++ b/src/internal/extension/AbstractNumberVerifier.mts
@@ -10,7 +10,7 @@ import {AbstractObjectVerifier} from "../internal.mjs";
  * @typeParam S - the type of validator returned by the methods
  */
 abstract class AbstractNumberVerifier<S, V extends ExtensibleNumberValidator<V>>
-	extends AbstractObjectVerifier<S, V>
+	extends AbstractObjectVerifier<S, V, number>
 	implements ExtensibleNumberVerifier<S>
 {
 	isNegative(): S
@@ -107,11 +107,6 @@ abstract class AbstractNumberVerifier<S, V extends ExtensibleNumberValidator<V>>
 	{
 		this.validator.isNotFinite();
 		return this.validationResult(() => this.getThis());
-	}
-
-	getActual(): number
-	{
-		return super.getActual() as number;
 	}
 }
 

--- a/src/internal/internal.mts
+++ b/src/internal/internal.mts
@@ -85,7 +85,6 @@ import {Node16MillionColors} from "./diff/Node16MillionColors.mjs";
 import {Node256Colors} from "./diff/Node256Colors.mjs";
 import type {GlobalConfiguration} from "../GlobalConfiguration.mjs";
 import {IllegalStateError} from "./IllegalStateError.mjs";
-import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 import {Maps} from "./Maps.mjs";
 import {SizeValidatorImpl} from "./SizeValidatorImpl.mjs";
 import {Pluralizer} from "./Pluralizer.mjs";
@@ -120,7 +119,6 @@ export
 	InetAddressValidatorImpl,
 	InetAddressVerifierImpl,
 	MainGlobalConfiguration,
-	TestGlobalConfiguration,
 	Maps,
 	MapValidatorImpl,
 	MapVerifierImpl,

--- a/test/ArrayTest.mts
+++ b/test/ArrayTest.mts
@@ -6,9 +6,9 @@ import {assert} from "chai";
 import {
 	Configuration,
 	TerminalEncoding,
-	TestGlobalConfiguration
-} from "../src/internal/internal.mjs";
-import {Requirements} from "../src/index.mjs";
+	Requirements
+} from "../src/index.mjs";
+import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 
 const globalConfiguration = new TestGlobalConfiguration(TerminalEncoding.NONE);
 const configuration = new Configuration(globalConfiguration);

--- a/test/BooleanTest.mts
+++ b/test/BooleanTest.mts
@@ -6,9 +6,9 @@ import {assert} from "chai";
 import {
 	Configuration,
 	TerminalEncoding,
-	TestGlobalConfiguration
-} from "../src/internal/internal.mjs";
-import {Requirements} from "../src/index.mjs";
+	Requirements
+} from "../src/index.mjs";
+import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 
 const globalConfiguration = new TestGlobalConfiguration(TerminalEncoding.NONE);
 const configuration = new Configuration(globalConfiguration);

--- a/test/ClassTest.mts
+++ b/test/ClassTest.mts
@@ -6,9 +6,9 @@ import {assert} from "chai";
 import {
 	Configuration,
 	TerminalEncoding,
-	TestGlobalConfiguration
-} from "../src/internal/internal.mjs";
-import {Requirements} from "../src/index.mjs";
+	Requirements
+} from "../src/index.mjs";
+import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 
 const globalConfiguration = new TestGlobalConfiguration(TerminalEncoding.NONE);
 const configuration = new Configuration(globalConfiguration);

--- a/test/ConfigurationTest.mts
+++ b/test/ConfigurationTest.mts
@@ -6,9 +6,9 @@ import {assert} from "chai";
 import {
 	Configuration,
 	TerminalEncoding,
-	TestGlobalConfiguration
-} from "../src/internal/internal.mjs";
-import {Requirements} from "../src/Requirements.mjs";
+	Requirements
+} from "../src/index.mjs";
+import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 
 const globalConfiguration = new TestGlobalConfiguration(TerminalEncoding.NONE);
 const configuration = new Configuration(globalConfiguration);

--- a/test/DiffTest.mts
+++ b/test/DiffTest.mts
@@ -11,10 +11,10 @@ import {
 	Node16MillionColors,
 	Node256Colors,
 	TerminalEncoding,
-	TestGlobalConfiguration,
 	TextOnly
 } from "../src/internal/internal.mjs";
-import {Requirements} from "../src/Requirements.mjs";
+import {Requirements} from "../src/index.mjs";
+import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 
 
 suite("DiffTest", () =>

--- a/test/InetAddressTest.mts
+++ b/test/InetAddressTest.mts
@@ -6,9 +6,9 @@ import {assert} from "chai";
 import {
 	Configuration,
 	TerminalEncoding,
-	TestGlobalConfiguration
-} from "../src/internal/internal.mjs";
-import {Requirements} from "../src/Requirements.mjs";
+	Requirements
+} from "../src/index.mjs";
+import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 
 const globalConfiguration = new TestGlobalConfiguration(TerminalEncoding.NONE);
 const configuration = new Configuration(globalConfiguration);

--- a/test/MapTest.mts
+++ b/test/MapTest.mts
@@ -1,14 +1,14 @@
-import {Requirements} from "../src/index.mjs";
+import {
+	Requirements,
+	Configuration,
+	TerminalEncoding
+} from "../src/index.mjs";
 import {
 	suite,
 	test
 } from "mocha";
 import {assert} from "chai";
-import {
-	Configuration,
-	TerminalEncoding,
-	TestGlobalConfiguration
-} from "../src/internal/internal.mjs";
+import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 
 const globalConfiguration = new TestGlobalConfiguration(TerminalEncoding.NONE);
 const configuration = new Configuration(globalConfiguration);

--- a/test/NumberTest.mts
+++ b/test/NumberTest.mts
@@ -1,14 +1,14 @@
-import {Requirements} from "../src/index.mjs";
+import {
+	Requirements,
+	Configuration,
+	TerminalEncoding
+} from "../src/index.mjs";
 import {
 	suite,
 	test
 } from "mocha";
 import {assert} from "chai";
-import {
-	Configuration,
-	TerminalEncoding,
-	TestGlobalConfiguration
-} from "../src/internal/internal.mjs";
+import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 
 const globalConfiguration = new TestGlobalConfiguration(TerminalEncoding.NONE);
 const configuration = new Configuration(globalConfiguration);

--- a/test/RequirementsTest.mts
+++ b/test/RequirementsTest.mts
@@ -1,14 +1,14 @@
-import {Requirements} from "../src/index.mjs";
+import {
+	Requirements,
+	Configuration,
+	TerminalEncoding
+} from "../src/index.mjs";
 import {
 	suite,
 	test
 } from "mocha";
 import {assert} from "chai";
-import {
-	Configuration,
-	TerminalEncoding,
-	TestGlobalConfiguration
-} from "../src/internal/internal.mjs";
+import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 
 const globalConfiguration = new TestGlobalConfiguration(TerminalEncoding.NONE);
 const configuration = new Configuration(globalConfiguration);
@@ -25,31 +25,31 @@ suite("RequirementsTest", () =>
 	test("assertThatArray", () =>
 	{
 		const actual = [1, 2, 3];
-		requirements.assertThat(r => r.requireThat(actual, "actual").isEqualTo("expected"));
+		requirements.assertThat(r => r.requireThat(actual, "actual").isEqualTo(actual, "expected"));
 	});
 
 	test("assertThatNumber", () =>
 	{
 		const actual = 5;
-		requirements.assertThat(r => r.requireThat(actual, "actual").isEqualTo("expected"));
+		requirements.assertThat(r => r.requireThat(actual, "actual").isEqualTo(actual, "expected"));
 	});
 
 	test("assertThatSet", () =>
 	{
 		const actual = new Set([1, 2, 3]);
-		requirements.assertThat(r => r.requireThat(actual, "actual").isEqualTo("expected"));
+		requirements.assertThat(r => r.requireThat(actual, "actual").isEqualTo(actual, "expected"));
 	});
 
 	test("assertThatMap", () =>
 	{
 		const actual = new Map([[1, 2], [2, 3]]);
-		requirements.assertThat(r => r.requireThat(actual, "actual").isEqualTo("expected"));
+		requirements.assertThat(r => r.requireThat(actual, "actual").isEqualTo(actual, "expected"));
 	});
 
 	test("assertThatUrl", () =>
 	{
 		const actual = new URL("http://www.google.com/");
-		requirements.assertThat(r => r.requireThat(actual, "actual").isEqualTo("expected"));
+		requirements.assertThat(r => r.requireThat(actual, "actual").isEqualTo(actual, "expected"));
 	});
 
 	test("withAssertionsEnabled.assertThatObject", () =>
@@ -110,7 +110,7 @@ suite("RequirementsTest", () =>
 		const actual = 12345;
 		const getActual = requirements.copy().withAssertionsEnabled().assertThatAndReturn(r =>
 			r.requireThat(actual, "actual").getActual());
-		requirements.requireThat(actual, "actual").isEqualTo(getActual, "getActual()");
+		requirements.requireThat(actual, "actual").isEqualTo(getActual as number, "getActual()");
 	});
 
 	test("assertThat.getActual_assertionsDisabled", () =>
@@ -118,7 +118,7 @@ suite("RequirementsTest", () =>
 		const actual = 12345;
 		const getActual = requirements.copy().withAssertionsDisabled().assertThatAndReturn(r =>
 			r.requireThat(actual, "actual").getActual());
-		requirements.requireThat(actual, "actual").isNotEqualTo(getActual, "getActual()");
+		requirements.requireThat(actual, "actual").isNotEqualTo(getActual as number, "getActual()");
 		requirements.requireThat(getActual, "getActual").isNotDefined();
 	});
 

--- a/test/SetTest.mts
+++ b/test/SetTest.mts
@@ -1,14 +1,14 @@
-import {Requirements} from "../src/index.mjs";
+import {
+	Requirements,
+	Configuration,
+	TerminalEncoding
+} from "../src/index.mjs";
 import {
 	suite,
 	test
 } from "mocha";
 import {assert} from "chai";
-import {
-	Configuration,
-	TerminalEncoding,
-	TestGlobalConfiguration
-} from "../src/internal/internal.mjs";
+import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 
 const globalConfiguration = new TestGlobalConfiguration(TerminalEncoding.NONE);
 const configuration = new Configuration(globalConfiguration);

--- a/test/SizeTest.mts
+++ b/test/SizeTest.mts
@@ -6,9 +6,9 @@ import {assert} from "chai";
 import {
 	Configuration,
 	TerminalEncoding,
-	TestGlobalConfiguration
-} from "../src/internal/internal.mjs";
-import {Requirements} from "../src/index.mjs";
+	Requirements
+} from "../src/index.mjs";
+import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 
 const globalConfiguration = new TestGlobalConfiguration(TerminalEncoding.NONE);
 const configuration = new Configuration(globalConfiguration);

--- a/test/StringTest.mts
+++ b/test/StringTest.mts
@@ -5,12 +5,12 @@ import {
 import {assert} from "chai";
 import {
 	Configuration,
-	EOS_MARKER,
 	TerminalEncoding,
-	TestGlobalConfiguration,
-	TextOnly
+	TextOnly,
+	EOS_MARKER
 } from "../src/internal/internal.mjs";
-import {Requirements} from "../src/Requirements.mjs";
+import {Requirements} from "../src/index.mjs";
+import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 
 const globalConfiguration = new TestGlobalConfiguration(TerminalEncoding.NONE);
 const configuration = new Configuration(globalConfiguration);
@@ -278,13 +278,13 @@ suite("StringTest", () =>
 	test("validateThatNullAsString", () =>
 	{
 		const actual = null;
-		const expected = 5;
+		const expected = "not-null";
 		const expectedMessage = "actual.asString() must be equal to " + expected + ".\n" +
 			"\n" +
-			"Actual  : null" + TextOnly.DIFF_PADDING + EOS_MARKER + "\n" +
-			"Diff    : " + TextOnly.DIFF_DELETE.repeat("null".length) + TextOnly.DIFF_INSERT +
-			TextOnly.DIFF_PADDING.repeat(EOS_MARKER.length) + "\n" +
-			"Expected: " + TextOnly.DIFF_PADDING.repeat("null".length) + "5" + EOS_MARKER;
+			"Actual  : n" + TextOnly.DIFF_PADDING.repeat("ot-n".length) + "ull" + EOS_MARKER + "\n" +
+			"Diff    : " + TextOnly.DIFF_EQUAL + TextOnly.DIFF_INSERT.repeat("on-n".length) +
+			TextOnly.DIFF_EQUAL.repeat("ull".length) + TextOnly.DIFF_PADDING.repeat(EOS_MARKER.length) + "\n" +
+			"Expected: not-null" + EOS_MARKER;
 		const expectedMessages = [expectedMessage];
 
 		const actualFailures = requirements.validateThat(actual, "actual").asString().isEqualTo(expected).

--- a/test/TestGlobalConfiguration.mts
+++ b/test/TestGlobalConfiguration.mts
@@ -1,5 +1,5 @@
-import type {TerminalEncoding} from "./internal.mjs";
-import {AbstractGlobalConfiguration} from "./internal.mjs";
+import type {TerminalEncoding} from "../src/index.mjs";
+import {AbstractGlobalConfiguration} from "../src/internal/internal.mjs";
 
 class TestGlobalConfiguration extends AbstractGlobalConfiguration
 {

--- a/test/TypescriptCompiler.mts
+++ b/test/TypescriptCompiler.mts
@@ -1,0 +1,99 @@
+import ts, {type CompilerHost} from "typescript";
+import * as path from "path";
+
+/**
+ * Detects whether a code snippet contains compilation errors.
+ */
+class TypeScriptCompiler
+{
+	// The root directory relative to which external files will be interpreted
+	private static readonly rootDir: string = path.resolve(".");
+	private static readonly fileToExclude = "build.mts";
+	private static readonly snippetFilename = "test.mts";
+	private static readonly config = TypeScriptCompiler.createParsedCommandLine();
+	private static readonly defaultCompilerHost = ts.createCompilerHost(TypeScriptCompiler.config.options);
+
+	private static createParsedCommandLine()
+	{
+		// Example of compiling using API: https://gist.github.com/jeremyben/4de4fdc40175d0f76892209e00ece98f
+		const configFile = ts.findConfigFile(TypeScriptCompiler.rootDir, ts.sys.fileExists, "tsconfig.json");
+		if (!configFile)
+			throw Error("tsconfig.json not found");
+		const {config} = ts.readConfigFile(configFile, ts.sys.readFile);
+
+		// We have to include at least one existing file to avoid CompilerHost throwing an exception
+		config.include = [TypeScriptCompiler.snippetFilename, TypeScriptCompiler.fileToExclude];
+		config.exclude.concat(["src/**", "test/**"]);
+
+		return ts.parseJsonConfigFileContent(config, ts.sys, TypeScriptCompiler.rootDir);
+	}
+
+	/**
+	 * Compiles a code snippet.
+	 *
+	 * @param snippet - the code to compile
+	 * @return the compiler warnings and errors
+	 */
+	public compile(snippet: string)
+	{
+		const compilerHost: CompilerHost = {
+			fileExists: ts.sys.fileExists,
+			readFile: fileName =>
+			{
+				if (fileName === TypeScriptCompiler.snippetFilename)
+					return snippet;
+				if (fileName === TypeScriptCompiler.fileToExclude)
+					return undefined;
+				return TypeScriptCompiler.defaultCompilerHost.readFile(fileName);
+			},
+			writeFile: () =>
+			{
+				// Avoid writing anything to disk
+			},
+			getSourceFile: (fileName, languageVersion, onError, shouldCreateNewSourceFile) =>
+			{
+				if (fileName === TypeScriptCompiler.snippetFilename)
+					return ts.createSourceFile(fileName, snippet, languageVersion);
+				if (fileName === TypeScriptCompiler.fileToExclude)
+					return undefined;
+				return TypeScriptCompiler.defaultCompilerHost.getSourceFile(fileName, languageVersion, onError,
+					shouldCreateNewSourceFile);
+			},
+			getCanonicalFileName: fileName =>
+			{
+				if (fileName === TypeScriptCompiler.snippetFilename)
+					return TypeScriptCompiler.snippetFilename;
+				return TypeScriptCompiler.defaultCompilerHost.getCanonicalFileName(fileName);
+			},
+			getDefaultLibFileName: (options) =>
+				TypeScriptCompiler.defaultCompilerHost.getDefaultLibFileName(options),
+			getCurrentDirectory: TypeScriptCompiler.defaultCompilerHost.getCurrentDirectory,
+			useCaseSensitiveFileNames: TypeScriptCompiler.defaultCompilerHost.useCaseSensitiveFileNames,
+			getNewLine: TypeScriptCompiler.defaultCompilerHost.getNewLine
+		};
+
+		const errors = TypeScriptCompiler.config.errors;
+		const program = ts.createProgram({
+			options: TypeScriptCompiler.config.options,
+			rootNames: [TypeScriptCompiler.snippetFilename],
+			configFileParsingDiagnostics: errors,
+			host: compilerHost
+		});
+
+		const {diagnostics} = program.emit();
+
+		const allDiagnostics = ts.getPreEmitDiagnostics(program).concat(diagnostics, errors);
+		if (allDiagnostics.length)
+		{
+			const formatHost: ts.FormatDiagnosticsHost = {
+				getCanonicalFileName: (path) => path,
+				getCurrentDirectory: ts.sys.getCurrentDirectory,
+				getNewLine: () => ts.sys.newLine
+			};
+			return ts.formatDiagnostics(allDiagnostics, formatHost);
+		}
+		return "";
+	}
+}
+
+export {TypeScriptCompiler};

--- a/test/ValidationFailureTest.mts
+++ b/test/ValidationFailureTest.mts
@@ -6,10 +6,10 @@ import {assert} from "chai";
 import {
 	Configuration,
 	TerminalEncoding,
-	TestGlobalConfiguration,
 	ValidationFailure
 } from "../src/internal/internal.mjs";
 import {Requirements} from "../src/index.mjs";
+import {TestGlobalConfiguration} from "./TestGlobalConfiguration.mjs";
 
 suite("ValidationFailureTest", () =>
 {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,8 @@
 		"node_modules",
 		"target",
 		"scripts",
-		"./.eslintrc.mjs"
+		"./.eslintrc.mjs",
+		"test/TestGlobalConfiguration.mts"
 	],
 	"typeRoots": [
 		"node_modules/@types"

--- a/wiki/Changelog.md
+++ b/wiki/Changelog.md
@@ -1,6 +1,10 @@
 Minor updates involving cosmetic changes have been omitted from this list. See
 https://github.com/cowwoc/requirements.java/commits/master for a full list.
 
+## Version 3.2.2 - 2023/11/23
+
+* Improvement: getActual() now returns a specific type instead of `unknown`.
+
 ## Version 3.2.1 - 2023/07/19
 
 * Breaking changes:

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -72,7 +72,7 @@ requireThat(nameToAge, "nameToAge").asMap().
 
 ## String diff
 
-When a [String comparison](https://cowwoc.github.io/requirements.js/3.2.1/docs/api/ObjectVerifier.html#isEqualTo)
+When a [String comparison](https://cowwoc.github.io/requirements.js/3.2.2/docs/api/ObjectVerifier.html#isEqualTo)
 fails, the library outputs a [diff](String_Diff.md) of the values being compared.
 
 ![colored-diff-example4.png](colored-diff-example4.png)

--- a/wiki/String_Diff.md
+++ b/wiki/String_Diff.md
@@ -1,4 +1,4 @@
-When a [String comparison](https://cowwoc.github.io/requirements.js/3.2.1/docs/api/ObjectVerifier.html#isEqualTo)
+When a [String comparison](https://cowwoc.github.io/requirements.js/3.2.2/docs/api/ObjectVerifier.html#isEqualTo)
 fails, the library outputs a [diff](https://en.wikipedia.org/wiki/Diff) of the values being compared.
 
 Depending on the terminal capability, you will see a [Textual](Textual_Diff.md) or [Colored](Colored_Diff.md) diff.
@@ -8,4 +8,4 @@ Depending on the terminal capability, you will see a [Textual](Textual_Diff.md) 
 We disable colors if stdout is redirected. This doesn't necessarily mean that ANSI codes are not supported, but we chose
 to err on the side of caution.
 Users can override this behavior by
-invoking [GlobalRequirements.withTerminalEncoding()](https://cowwoc.github.io/requirements.js/3.2.1/docs/api/module-GlobalRequirements-GlobalRequirements.html#.withTerminalEncoding).
+invoking [GlobalRequirements.withTerminalEncoding()](https://cowwoc.github.io/requirements.js/3.2.2/docs/api/module-GlobalRequirements-GlobalRequirements.html#.withTerminalEncoding).


### PR DESCRIPTION
* getActual() now returns a specific type instead of unknown.
* Moved TestGlobalConfiguration out of published source-code.
* Test that invalid type comparisons result in compile-time errors.
* Bugfix: StringValidator.toString() should not cast null to "null" if the validator contains failures.